### PR TITLE
Move set_smbios inside build_efi

### DIFF
--- a/OpenCore-Patcher.command
+++ b/OpenCore-Patcher.command
@@ -14,7 +14,6 @@ class OpenCoreLegacyPatcher():
         self.constants = Constants.Constants()
         self.custom_model: str = None
         self.current_model: str = None
-        self.boot_verbose: str = "yes"
         opencore_model: str = subprocess.run("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:oem-product".split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode()
         if not opencore_model.startswith("nvram: Error getting variable"):
             opencore_model = [line.strip().split(":oem-product	", 1)[1] for line in opencore_model.split("\n") if line.strip().startswith("4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:")][0]
@@ -24,7 +23,7 @@ class OpenCoreLegacyPatcher():
             self.current_model = [line.strip().split(": ", 1)[1] for line in self.current_model.stdout.decode().split("\n") if line.strip().startswith("Model Identifier")][0]
 
     def build_opencore(self):
-        build.BuildOpenCore(self.custom_model or self.current_model, self.constants, self.boot_verbose).build_opencore()
+        build.BuildOpenCore(self.custom_model or self.current_model, self.constants).build_opencore()
 
     def install_opencore(self):
         build.BuildOpenCore(self.custom_model or self.current_model, self.constants).copy_efi()
@@ -39,12 +38,6 @@ system_profiler SPHardwareDataType | grep 'Model Identifier'
     """)
         self.custom_model = input("Please enter the model identifier of the target machine: ").strip()
 
-    def toggle_verbose(self):
-        if (self.boot_verbose == 'yes'): 
-            self.boot_verbose = 'no'
-        else:
-            self.boot_verbose = 'yes'
-
     def credits(self):
         utilities.TUIOnlyPrint(["Credits"], "Press [Enter] to go back.\n",
                                ["""Many thanks to the following:
@@ -54,7 +47,6 @@ system_profiler SPHardwareDataType | grep 'Model Identifier'
   - DhinakG:\t\tWriting and maintaining this patcher
   - Syncretic:\t\tAAAMouSSE and telemetrap
   - Slice:\t\tVoodooHDA"""]).start()
-
 
     def main_menu(self):
         response = None
@@ -89,7 +81,6 @@ system_profiler SPHardwareDataType | grep 'Model Identifier'
             options = ([["Build OpenCore", self.build_opencore]] if ((self.custom_model or self.current_model) in ModelArray.SupportedSMBIOS) else []) + [
                 ["Install OpenCore to USB/internal drive", self.install_opencore],
                 ["Change Model", self.change_model],
-                ["Toggle Verbose Logging ("+self.boot_verbose+")", self.toggle_verbose],
                 ["Credits", self.credits]
             ]
 

--- a/OpenCore-Patcher.command
+++ b/OpenCore-Patcher.command
@@ -14,6 +14,7 @@ class OpenCoreLegacyPatcher():
         self.constants = Constants.Constants()
         self.custom_model: str = None
         self.current_model: str = None
+        self.boot_verbose: str = "yes"
         opencore_model: str = subprocess.run("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:oem-product".split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode()
         if not opencore_model.startswith("nvram: Error getting variable"):
             opencore_model = [line.strip().split(":oem-product	", 1)[1] for line in opencore_model.split("\n") if line.strip().startswith("4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:")][0]
@@ -23,7 +24,7 @@ class OpenCoreLegacyPatcher():
             self.current_model = [line.strip().split(": ", 1)[1] for line in self.current_model.stdout.decode().split("\n") if line.strip().startswith("Model Identifier")][0]
 
     def build_opencore(self):
-        build.BuildOpenCore(self.custom_model or self.current_model, self.constants).build_opencore()
+        build.BuildOpenCore(self.custom_model or self.current_model, self.constants, self.boot_verbose).build_opencore()
 
     def install_opencore(self):
         build.BuildOpenCore(self.custom_model or self.current_model, self.constants).copy_efi()
@@ -38,6 +39,12 @@ system_profiler SPHardwareDataType | grep 'Model Identifier'
     """)
         self.custom_model = input("Please enter the model identifier of the target machine: ").strip()
 
+    def toggle_verbose(self):
+        if (self.boot_verbose == 'yes'): 
+            self.boot_verbose = 'no'
+        else:
+            self.boot_verbose = 'yes'
+
     def credits(self):
         utilities.TUIOnlyPrint(["Credits"], "Press [Enter] to go back.\n",
                                ["""Many thanks to the following:
@@ -47,6 +54,7 @@ system_profiler SPHardwareDataType | grep 'Model Identifier'
   - DhinakG:\t\tWriting and maintaining this patcher
   - Syncretic:\t\tAAAMouSSE and telemetrap
   - Slice:\t\tVoodooHDA"""]).start()
+
 
     def main_menu(self):
         response = None
@@ -81,6 +89,7 @@ system_profiler SPHardwareDataType | grep 'Model Identifier'
             options = ([["Build OpenCore", self.build_opencore]] if ((self.custom_model or self.current_model) in ModelArray.SupportedSMBIOS) else []) + [
                 ["Install OpenCore to USB/internal drive", self.install_opencore],
                 ["Change Model", self.change_model],
+                ["Toggle Verbose Logging ("+self.boot_verbose+")", self.toggle_verbose],
                 ["Credits", self.credits]
             ]
 

--- a/Resources/build.py
+++ b/Resources/build.py
@@ -139,6 +139,8 @@ class BuildOpenCore:
         shutil.copy(self.constants.gui_path, self.constants.oc_folder)
         self.config["UEFI"]["Drivers"] = ["OpenCanopy.efi", "OpenRuntime.efi"]
 
+        self.set_smbios()
+
         plistlib.dump(self.config, Path(self.constants.plist_path).open("wb"), sort_keys=True)
 
     def set_smbios(self):
@@ -220,7 +222,6 @@ class BuildOpenCore:
 
     def build_opencore(self):
         self.build_efi()
-        self.set_smbios()
         self.cleanup()
         print("")
         print("Your OpenCore EFI has been built at:")

--- a/Resources/build.py
+++ b/Resources/build.py
@@ -28,10 +28,11 @@ def rmtree_handler(func, path, exc_info):
 
 
 class BuildOpenCore:
-    def __init__(self, model, versions):
+    def __init__(self, model, versions, verbose):
         self.model = model
         self.config = None
         self.constants: Constants.Constants = versions
+        self.boot_verbose = verbose
 
     def build_efi(self):
         utilities.cls()
@@ -125,9 +126,19 @@ class BuildOpenCore:
             self.get_kext_by_bundle_path("USB-Map-SMBIOS.kext")["Enabled"] = True
             self.get_kext_by_bundle_path("USB-Map-SMBIOS.kext")["BundlePath"] = map_entry
 
+	# Boot Args
+        boot_args = []
+        if self.boot_verbose == 'yes':
+            print("- Booting verbose")
+            boot_args.append("-v")
+            boot_args.append("keepsyms=1")
+            boot_args.append("debug=0x100")
+
         if self.model in ModelArray.DualGPUPatch:
             print("- Adding dual GPU patch")
-            self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " agdpmod=pikera"
+            boot_args.append("agdpmod=pikera")
+       
+        self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] = ' '.join([str(arg) for arg in boot_args])
 
         if self.model in ModelArray.HiDPIpicker:
             print("- Setting HiDPI picker")

--- a/Resources/build.py
+++ b/Resources/build.py
@@ -28,11 +28,10 @@ def rmtree_handler(func, path, exc_info):
 
 
 class BuildOpenCore:
-    def __init__(self, model, versions, verbose):
+    def __init__(self, model, versions):
         self.model = model
         self.config = None
         self.constants: Constants.Constants = versions
-        self.boot_verbose = verbose
 
     def build_efi(self):
         utilities.cls()
@@ -126,19 +125,9 @@ class BuildOpenCore:
             self.get_kext_by_bundle_path("USB-Map-SMBIOS.kext")["Enabled"] = True
             self.get_kext_by_bundle_path("USB-Map-SMBIOS.kext")["BundlePath"] = map_entry
 
-	# Boot Args
-        boot_args = []
-        if self.boot_verbose == 'yes':
-            print("- Booting verbose")
-            boot_args.append("-v")
-            boot_args.append("keepsyms=1")
-            boot_args.append("debug=0x100")
-
         if self.model in ModelArray.DualGPUPatch:
             print("- Adding dual GPU patch")
-            boot_args.append("agdpmod=pikera")
-       
-        self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] = ' '.join([str(arg) for arg in boot_args])
+            self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " agdpmod=pikera"
 
         if self.model in ModelArray.HiDPIpicker:
             print("- Setting HiDPI picker")


### PR DESCRIPTION
Since build_efi generates the config, SMBIOS settings are no longer getting spoofed in the resulting config.