### PR TITLE
PlatformFeature -> new 0.6.7 OEM detect value

### DIFF
--- a/payloads/Config/v0.6.8/config.plist
+++ b/payloads/Config/v0.6.8/config.plist
@@ -997,7 +997,7 @@
 			<key>FirmwareFeaturesMask</key>
 			<data></data>
 			<key>PlatformFeature</key>
-			<integer>0</integer>
+			<integer>-1</integer>
 			<key>ProcessorType</key>
 			<integer>0</integer>
 			<key>SmcVersion</key>


### PR DESCRIPTION
See this commit for new feature https://github.com/acidanthera/OpenCorePkg/pull/215 and this question for clarification about whether -1 is an okay way to write the value https://github.com/acidanthera/bugtracker/issues/1543