### PR TITLE
make OLCP EFI default boot object

### DIFF
--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -2,7 +2,7 @@
 
 Now we finally get to boot OpenCore!
 
-Reboot machine while holding `Option` to select the EFI Boot entry with the OpenCore icon:
+Reboot machine while holding `Option` to select the EFI Boot entry with the OpenCore icon while holding the `control` key:
 
 * This will be the Mac Boot Picker
 


### PR DESCRIPTION
Select EFI by pressing control. You should possibly change the picture (../images/efi-boot.png) with one showing the circle arrow in that case!