### PR TITLE
Adding successful report of MacBookPro7,1

### DIFF
--- a/docs/TESTED.md
+++ b/docs/TESTED.md
@@ -42,7 +42,7 @@ To aid users in troubleshooting, we've compiled a list of users who've reported 
 | MacBookPro5,5 | ^^ | ^^ | ^^ |
 | MacBookPro6,1 | ^^ | ^^ | ^^ |
 | MacBookPro6,2 | <span style="color:#30BCD5"> YES </span> | Jakeluke | - Stock model, dGPU broken <br/>- Patcher version unknown |
-| MacBookPro7,1 | No reports | N/A | N/A |
+| MacBookPro7,1 | <span style="color:#30BCD5"> YES </span> | fussel132 | - Stock model (Mac-F222BEC8)<br/>-Patcher version v0.1.2 |
 | MacBookPro8,1 | <span style="color:#30BCD5"> YES </span> | AvaQueen | - Stock model <br/>- Patcher version 0.0.19 |
 | MacBookPro8,2 | ^^ | air.man | - Stock model, dGPU disabled <br/>- Patcher version 0.0.22 |
 | ^^ | ^^ | cboukouv | - Stock model <br/>- Patcher version 0.0.19 |


### PR DESCRIPTION
Tried out Big Sur 11.3 on MacBookPro7,1 with OpenCore patcher version v0.1.2, working fine (with graphics acceleration).  Not working: Keyboard backlight and graphical issues with sliders in control center.