### PR TITLE
Add TeraScale 2 patches

### DIFF
--- a/Resources/Build.py
+++ b/Resources/Build.py
@@ -130,7 +130,7 @@ class BuildOpenCore:
             ("Lilu.kext", self.constants.lilu_version, self.constants.lilu_path, lambda: True),
             ("WhateverGreen.kext", self.constants.whatevergreen_version, self.constants.whatevergreen_path, lambda: self.constants.allow_oc_everywhere is False),
             ("RestrictEvents.kext", self.constants.restrictevents_version, self.constants.restrictevents_path, lambda: self.model in ModelArray.MacPro71),
-            ("RestrictEvents.kext", self.constants.restrictevents_mbp_version, self.constants.restrictevents_mbp_path, lambda: self.model in ["MacBookPro6,1", "MacBookPro6,2", "MacBookPro9,1"]),
+            ("RestrictEvents.kext", self.constants.restrictevents_mbp_version, self.constants.restrictevents_mbp_path, lambda: self.model in ["MacBookPro6,1", "MacBookPro6,2", "MacBookPro8,2", "MacBookPro8,3", "MacBookPro9,1"]),
             ("NightShiftEnabler.kext", self.constants.nightshift_version, self.constants.nightshift_path, lambda: self.model not in ModelArray.NightShiftExclude and self.constants.allow_oc_everywhere is False and self.constants.serial_settings == "Minimal"),
             ("SMC-Spoof.kext", self.constants.smcspoof_version, self.constants.smcspoof_path, lambda: self.constants.allow_oc_everywhere is False),
             # CPU patches

--- a/Resources/Constants.py
+++ b/Resources/Constants.py
@@ -39,7 +39,7 @@ class Constants:
         self.nvmefix_version = "1.0.7"
         self.sidecarfixup_version = "1.0.0"
         self.innie_version = "1.3.0"
-        self.payload_version = "0.0.8"
+        self.payload_version = "0.0.12"
 
         # Get resource path
         self.current_path = Path(__file__).parent.parent.resolve()

--- a/Resources/SysPatch.py
+++ b/Resources/SysPatch.py
@@ -160,10 +160,12 @@ class PatchSysVolume:
                 print("- Creating mnt1 folder")
                 Path(self.constants.payload_mnt1_path).mkdir()
         else:
-            root_partition_info = plistlib.loads(subprocess.run("diskutil info -plist /System/Volumes/Update/mnt1".split(), stdout=subprocess.PIPE).stdout.decode().strip().encode())
+            root_partition_info = plistlib.loads(subprocess.run("diskutil info -plist /".split(), stdout=subprocess.PIPE).stdout.decode().strip().encode())
             self.root_mount_path = root_partition_info["DeviceIdentifier"]
 
         if self.root_mount_path.startswith("disk"):
+            if self.constants.recovery_status is False:
+                self.root_mount_path = self.root_mount_path[:-2] if self.root_mount_path.count("s") > 1 else self.root_mount_path
             print(f"- Found Root Volume at: {self.root_mount_path}")
             if Path(self.mount_extensions).exists():
                 print("- Root Volume is already mounted")

--- a/Resources/SysPatch.py
+++ b/Resources/SysPatch.py
@@ -231,6 +231,7 @@ class PatchSysVolume:
         self.elevated(["chown", "-Rf", "root:wheel", f"{self.mount_private_frameworks}/DisplayServices.framework"], stdout=subprocess.PIPE).stdout.decode().strip().encode()
 
     def gpu_accel_patches_11(self):
+        self.ts2_patch_set = False
         igpu_vendor, igpu_device, igpu_acpi = DeviceProbe.pci_probe().gpu_probe("IGPU")
         dgpu_vendor, dgpu_device, dgpu_acpi = DeviceProbe.pci_probe().gpu_probe("GFX0")
         if dgpu_vendor:


### PR DESCRIPTION
Currently experimental, only iMacs and Skylake Hackintosh tested. 

SSE4,2 required, MouSSE is currently [non-functional in Big Sur](https://forums.macrumors.com/threads/mp3-1-others-sse-4-2-emulation-to-enable-amd-metal-driver.2206682/post-29963384)