### PR TITLE
Support HiDPI Picker for Newly Unsupported Macs

### DIFF
--- a/Resources/ModelArray.py
+++ b/Resources/ModelArray.py
@@ -613,8 +613,12 @@ IntelNvidiaDRM = [
 ]
 
 HiDPIpicker = [
+    "MacBook8,1",
     "MacBookPro10,1",
     "MacBookPro10,2",
+    "MacBookPro11,1",
+    "MacBookPro11,2",
+    "MacBookPro11,3",
     "Dortania1,1"
 ]
 


### PR DESCRIPTION
Tested newest branch on MBP11,2 and found that UIScale is on default set to 01.