### PR TITLE
Fix MacBook8,1 SMBIOS Spoofing

### DIFF
--- a/Resources/Build.py
+++ b/Resources/Build.py
@@ -43,6 +43,9 @@ class BuildOpenCore:
         elif self.model in ModelArray.MacBookAir62:
             print("- Spoofing to MacBookAir7,2")
             return "MacBookAir7,2"
+        elif self.model in ModelArray.MacBook81:
+            print("- Spoofing to MacBook9,1")
+            return "MacBook9,1"
         elif self.model in ModelArray.MacBookPro111:
             print("- Spoofing to MacBookPro12,1")
             return "MacBookPro12,1"

--- a/Resources/ModelArray.py
+++ b/Resources/ModelArray.py
@@ -640,7 +640,7 @@ MacBookAir61 = [
     "MacBookAir6,1",
 ]
 
-# MacBook and 13" Air
+# Classic MacBook and 13" Air
 MacBookAir62 = [
     "MacBook4,1",
     "MacBook5,1",
@@ -652,6 +652,11 @@ MacBookAir62 = [
     "MacBookAir4,2",
     "MacBookAir5,2",
     "MacBookAir6,2",
+]
+
+# Retina MacBook
+MacBook81 = [
+    "MacBook8,1",
 ]
 
 # MacBook Pro 13"


### PR DESCRIPTION
As a bug indicated by OCLP discord, the lack of spoofing MB8,1 to MB9,1 is added.