### PR TITLE
Update TCC modification in ACCEL.md for Big Sur

### DIFF
--- a/docs/ACCEL.md
+++ b/docs/ACCEL.md
@@ -41,7 +41,8 @@ chmod +x tccplus
 ./tccplus add Microphone com.hnc.Discord
 ```
 
-In Big Sur currently `tccplus` and like utilities no longer work and this requires something more along the lines of this:
+For those who may experience issues with `tccplus`, you can manually patch `com.apple.TCC` ti add permissions:
+
 ```sh
 # get app id (Zoom.us used in example):
 $ osascript -e 'id of app "zoom.us"'

--- a/docs/ACCEL.md
+++ b/docs/ACCEL.md
@@ -41,6 +41,17 @@ chmod +x tccplus
 ./tccplus add Microphone com.hnc.Discord
 ```
 
+In Big Sur currently `tccplus` and like utilities no longer work and this requires something more along the lines of this:
+```sh
+# get app id (Zoom.us used in example):
+$ osascript -e 'id of app "zoom.us"'
+# output: us.zoom.xos
+
+$ sudo sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT or REPLACE INTO access VALUES('kTCCServiceMicrophone','us.zoom.xos',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1541440109);"
+
+$ sudo sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT or REPLACE INTO access VALUES('kTCCServiceCamera','us.zoom.xos',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1541440109);"
+```
+
 ## Keyboard Backlight broken
 
 Due to forcing `hidd` into spinning up with the fallback mode enabled, this can break the OS's recognition of backlight keyboards. Thankfully the drivers themselves still do operate so applications such as [LabTick](https://www.macupdate.com/app/mac/22151/lab-tick) are able to set the brightness manually.

--- a/docs/ACCEL.md
+++ b/docs/ACCEL.md
@@ -41,7 +41,7 @@ chmod +x tccplus
 ./tccplus add Microphone com.hnc.Discord
 ```
 
-For those who may experience issues with `tccplus`, you can manually patch `com.apple.TCC` ti add permissions:
+For those who may experience issues with `tccplus`, you can manually patch `com.apple.TCC` to add permissions:
 
 ```sh
 # get app id (Zoom.us used in example):


### PR DESCRIPTION
Since TCC modifying utilities no longer work for Big Sur+, providing optional instructions to deal with manual addition to TCC database.