### PR TITLE
Add Latebloom support

### DIFF
--- a/OpenCore-Patcher.command
+++ b/OpenCore-Patcher.command
@@ -129,10 +129,10 @@ system_profiler SPHardwareDataType | grep 'Model Identifier'
                     f"Allow OpenCore on native Models:\tCurrently {self.constants.allow_oc_everywhere}",
                     CliMenu.MenuOptions(self.constants.custom_model or self.computer.real_model, self.constants).allow_native_models,
                 ],
-                # [
-                #    f"Latebloom settings:\t\t\tDelay {self.constants.latebloom_delay}, Range {self.constants.latebloom_range}, Debug {self.constants.latebloom_debug}",
-                #    CliMenu.MenuOptions(self.constants.custom_model or self.computer.real_model, self.constants).latebloom_settings,
-                # ],
+                [
+                   f"Latebloom settings:\t\tDelay {self.constants.latebloom_delay}, Range {self.constants.latebloom_range}, Debug {self.constants.latebloom_debug}",
+                   CliMenu.MenuOptions(self.constants.custom_model or self.computer.real_model, self.constants).latebloom_settings,
+                ],
                 ["Advanced Patch Settings, for developers only", self.advanced_patcher_settings],
             ]
 

--- a/Resources/Build.py
+++ b/Resources/Build.py
@@ -170,7 +170,7 @@ class BuildOpenCore:
             # Misc
             ("FeatureUnlock.kext", self.constants.featureunlock_version, self.constants.featureunlock_path, lambda: self.model in ModelArray.SidecarPatch),
             ("DebugEnhancer.kext", self.constants.debugenhancer_version, self.constants.debugenhancer_path, lambda: self.constants.kext_debug is True),
-            # ("latebloom.kext", self.constants.latebloom_version, self.constants.latebloom_path, lambda: self.model in ModelArray.PCIRaceCondition),
+            ("latebloom.kext", self.constants.latebloom_version, self.constants.latebloom_path, lambda: self.model in ModelArray.PCIRaceCondition),
         ]:
             self.enable_kext(name, version, path, check)
 

--- a/Resources/Build.py
+++ b/Resources/Build.py
@@ -178,7 +178,7 @@ class BuildOpenCore:
             self.get_item_by_kv(self.config["Kernel"]["Patch"], "Identifier", "com.apple.driver.AppleSMC")["Enabled"] = True
 
         if self.get_kext_by_bundle_path("latebloom.kext")["Enabled"] is True:
-            print(f"- Setting latebloom delay of {self.constants.latebloom_delay}, range {self.constants.latebloom_range}, debug {self.constants.latebloom_debug}")
+            print(f"- Setting latebloom delay of {self.constants.latebloom_delay}ms, range {self.constants.latebloom_range}ms, debug {bool(self.constants.latebloom_debug)}")
             self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"][
                 "boot-args"
             ] += f" latebloom={self.constants.latebloom_delay}, lb_range={self.constants.latebloom_range}, lb_debug={self.constants.latebloom_debug}"

--- a/Resources/CliMenu.py
+++ b/Resources/CliMenu.py
@@ -536,9 +536,9 @@ pre-Sandy Bridge Macs.
 
 Valid options:
 
-1. Set delay (currently: {self.constants.latebloom_delay})
-2. Set range (currently: {self.constants.latebloom_range})
-3. Set debug (currently: {self.constants.latebloom_debug})
+1. Set delay (currently: {self.constants.latebloom_delay}ms)
+2. Set range (currently: {self.constants.latebloom_range}ms)
+3. Set debug (currently: {bool(self.constants.latebloom_debug)})
         """
         )
 
@@ -555,8 +555,8 @@ Valid options:
                 input("Invalid value, press [ENTER] to continue")
         elif change_menu == "3":
             try:
-                print("Currently supports either 0(debug disabled) or 1(debug enabled)")
-                latebloom_debug = int(input("Set debug: "))
+                print("Currently supports either 0(False) or 1(True)")
+                latebloom_debug = int(input("Set debug(0/1): "))
                 if latebloom_debug not in [0, 1]:
                     input("Invalid value, press [ENTER] to continue")
                 else:

--- a/Resources/CliMenu.py
+++ b/Resources/CliMenu.py
@@ -542,7 +542,7 @@ Valid options:
         """
         )
 
-        change_menu = input("Set latebloom properties: ")
+        change_menu = input("Select latebloom property(1/2/3): ")
         if change_menu == "1":
             try:
                 self.constants.latebloom_delay = int(input("Set delay: "))
@@ -555,7 +555,12 @@ Valid options:
                 input("Invalid value, press [ENTER] to continue")
         elif change_menu == "3":
             try:
-                self.constants.latebloom_debug = int(input("Set debug: "))
+                print("Currently supports either 0(debug disabled) or 1(debug enabled)")
+                latebloom_debug = int(input("Set debug: "))
+                if latebloom_debug not in [0, 1]:
+                    input("Invalid value, press [ENTER] to continue")
+                else:
+                    self.constants.latebloom_debug = latebloom_debug
             except ValueError:
                 input("Invalid value, press [ENTER] to continue")
         else:


### PR DESCRIPTION
Currently this PR is solely for testing and validation of latebloom with macOS 11.3 and newer.

Goal of this PR is to resolve the PCI Race Condition present within macOS 11.3 and newer builds, further information can be found on the MacRumors thread:

* [Latebloom - An experimental workaround for the 11.3+ race condition](https://forums.macrumors.com/threads/latebloom-an-experimental-workaround-for-the-11-3-race-condition.2303986/)

Currently this PR will enforce the following values on [pre-Sandy Bridge Macs](https://github.com/dortania/OpenCore-Legacy-Patcher/blob/e94264f0399b7824847b72c30deb1eb17aae292c/Resources/ModelArray.py#L997-L1028):

* latebloom delay = 100ms
* latebloom range = 1ms
* latebloom debug = 1 (True)

For MacPro4,1, MacPro5,1, iMac7,1 and iMac8,1, latebloom delay has been increased to 250ms as these machines are generally more problematic. Users can further configure their delays, ranges and debug value within `Patcher Settings -> Latebloom settings`:

<img width="697" alt="Screen Shot 2021-07-20 at 9 30 34 AM" src="https://user-images.githubusercontent.com/48863253/126352210-c758cd49-90fd-4202-9566-d72d6865146b.png">

### Additional Notes

* Ensure you have a native OS to return to in the event of an issue
  * OCLP will not inject latebloom on pre-11.3 OSes so in the event of an issue, older OSes should be safe however please be aware that proper fallbacks are recommended
* To disable latebloom functionality, set delay to 0ms.  
* Please report issues and successes either on [our discord]() or on the [MacRumors' forum](https://forums.macrumors.com/threads/latebloom-an-experimental-workaround-for-the-11-3-race-condition.2303986/)

