### PR TITLE
Allow FileVault on Root Patched Macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
   - TeraScale 2 acceleration to be added in the future
 - Allow Trackpad gestures on MacBook4,1 and MacBook5,2
   - System Preferences will not report settings however
+- Allow Root Volume Patched Systems to use FileVault 2
+  - Requires macOS 11.3 (20E232) or newer
 
 ## 0.2.4
 

--- a/OCLP-CLI.command
+++ b/OCLP-CLI.command
@@ -213,18 +213,19 @@ If you plan to create the USB for another machine, please select the "Change Mod
                 # self.constants.secure_status = True  # Monterey
                 self.constants.amfi_status = True
             elif host_is_target:
-                self.constants.sip_status = False  # Unsigned kexts
+                self.constants.sip_status = False  #    Unsigned kexts
                 self.constants.secure_status = False  # Root volume modified
-                self.constants.amfi_status = False  # Unsigned binaries
+                self.constants.amfi_status = False  #   Unsigned binaries
         if model in ModelArray.ModernGPU:
             if host_is_target and model in ["iMac13,1", "iMac13,3"] and self.computer.dgpu:
                 # Some models have a supported dGPU, others don't
                 print("- Detected Metal dGPU, overriding default configuration")
                 self.constants.sip_status = True
             elif host_is_target:
-                self.constants.sip_status = False  # Unsigned kexts
+                self.constants.sip_status = False  #    Unsigned kexts
                 self.constants.secure_status = False  # Modified root volume
-                # self.constants.amfi_status = True  # Signed bundles, Don't need to explicitly set currently
+                self.constants.allow_fv_root = True  #  Allow FileVault on broken seal
+                # self.constants.amfi_status = True  #  Signed bundles, Don't need to explicitly set currently
         if model == "MacBook8,1" and host_is_target:
             # MacBook8,1 has an odd bug where it cannot install Monterey with Minimal spoofing
             self.constants.serial_settings == "Moderate"

--- a/OpenCore-Patcher.command
+++ b/OpenCore-Patcher.command
@@ -53,11 +53,12 @@ class OpenCoreLegacyPatcher:
                 # Some models have a supported dGPU, others don't
                 self.constants.sip_status = True
                 # self.constants.secure_status = True  # Monterey
-                # self.constants.amfi_status = True  # Signed bundles, Don't need to explicitly set currently
+                # self.constants.amfi_status = True  #  Signed bundles, Don't need to explicitly set currently
             else:
-                self.constants.sip_status = False  # Unsigned kexts
+                self.constants.sip_status = False  #    Unsigned kexts
                 self.constants.secure_status = False  # Modified root volume
-                # self.constants.amfi_status = True  # Signed bundles, Don't need to explicitly set currently
+                self.constants.allow_fv_root = True  #  Allow FileVault on broken seal
+                # self.constants.amfi_status = True  #  Signed bundles, Don't need to explicitly set currently
         if model == "MacBook8,1":
             # MacBook8,1 has an odd bug where it cannot install Monterey with Minimal spoofing
             self.constants.serial_settings = "Moderate"

--- a/OpenCore-Patcher.command
+++ b/OpenCore-Patcher.command
@@ -44,9 +44,10 @@ class OpenCoreLegacyPatcher:
                 # self.constants.secure_status = True  # Monterey
                 self.constants.amfi_status = True
             else:
-                self.constants.sip_status = False  # Unsigned kexts
+                self.constants.sip_status = False  #    Unsigned kexts
                 self.constants.secure_status = False  # Root volume modified
-                self.constants.amfi_status = False  # Unsigned binaries
+                self.constants.amfi_status = False  #   Unsigned binaries
+                self.constants.allow_fv_root = True  #  Allow FileVault on broken seal
         if model in ModelArray.ModernGPU:
             if host_is_target and model in ["iMac13,1", "iMac13,3"] and self.computer.dgpu:
                 # Some models have a supported dGPU, others don't

--- a/OpenCore-Patcher.command
+++ b/OpenCore-Patcher.command
@@ -291,8 +291,7 @@ system_profiler SPHardwareDataType | grep 'Model Identifier'
 
 WARNING: Root Volume Patching is still in active development, please
 have all important user data backed up. Note when the system volume
-is patched, you can no longer have Delta updates or have FileVault
-enabled.
+is patched, you can no longer have Delta updates.
 
 Supported Options:
 
@@ -314,8 +313,7 @@ B. Exit
 
 WARNING: Root Volume Patching is still in active development, please
 have all important user data backed up. Note when the system volume
-is patched, you can no longer have Delta updates or have FileVault
-enabled.
+is patched, you can no longer have Delta updates.
 
 Supported Options:
 
@@ -333,8 +331,7 @@ B. Exit
 
 WARNING: Root Volume Patching is still in active development, please
 have all important user data backed up. Note when the system volume
-is patched, you can no longer have Delta updates or have FileVault
-enabled.
+is patched, you can no longer have Delta updates.
 
 Supported Options:
 

--- a/Resources/Build.py
+++ b/Resources/Build.py
@@ -686,6 +686,13 @@ class BuildOpenCore:
         if self.model in ModelArray.dGPU_switch:
             print("- Allowing GMUX switching in Windows")
             self.config["Booter"]["Quirks"]["SignalAppleOS"] = True
+        # if self.constants.allow_fv_root is True:
+            # apfs.kext has an undocumented boot-arg that allows FileVault usage on broken APFS seals (-arv_allow_fv)
+            # This is however hidden behind kern.development, thus we patch _apfs_filevault_allowed to always return true
+            # Note this function was added in 11.3 (20E232, 20.4), older builds do not support this (ie. 11.2.3)
+        print("- Allowing FileVault on Root Patched systems")
+        self.get_item_by_kv(self.config["Kernel"]["Patch"], "Identifier", "com.apple.filesystems.apfs")["Enabled"] = True
+
 
     def set_smbios(self):
         spoofed_model = self.model

--- a/Resources/Build.py
+++ b/Resources/Build.py
@@ -686,12 +686,12 @@ class BuildOpenCore:
         if self.model in ModelArray.dGPU_switch:
             print("- Allowing GMUX switching in Windows")
             self.config["Booter"]["Quirks"]["SignalAppleOS"] = True
-        # if self.constants.allow_fv_root is True:
+        if self.constants.allow_fv_root is True:
             # apfs.kext has an undocumented boot-arg that allows FileVault usage on broken APFS seals (-arv_allow_fv)
             # This is however hidden behind kern.development, thus we patch _apfs_filevault_allowed to always return true
             # Note this function was added in 11.3 (20E232, 20.4), older builds do not support this (ie. 11.2.3)
-        print("- Allowing FileVault on Root Patched systems")
-        self.get_item_by_kv(self.config["Kernel"]["Patch"], "Identifier", "com.apple.filesystems.apfs")["Enabled"] = True
+            print("- Allowing FileVault on Root Patched systems")
+            self.get_item_by_kv(self.config["Kernel"]["Patch"], "Identifier", "com.apple.filesystems.apfs")["Enabled"] = True
 
 
     def set_smbios(self):

--- a/Resources/CliMenu.py
+++ b/Resources/CliMenu.py
@@ -481,7 +481,7 @@ For iMac13,x systems with a Nvidia dGPU, the iGPU is disabled by default to
 allow Delta Updates, FileVault, SIP and such on macOS Monterey. However due to
 this, DRM and QuickSync support may be broken.
 
-Users can choose to override this option but be aware SIP and FileVault must be
+Users can choose to override this option but be aware SIP must be
 disabled to run root patches to fix DRM and QuickSync.
 
 Note: This does not apply for Big Sur, the iGPU can be renabled without
@@ -556,7 +556,7 @@ patches in Mojave and Catalina.
 
 The main goal of this is to allow developers to better test patch sets as well
 as allow acceleration on TeraScale 2 machines. Not all features may be available
-(ie. GPU switching may not work, FileVault is not supported, etc)
+(ie. GPU switching may not work, etc)
 
 Note: for the average user, we recommend using dosdude1's legacy patcher:
 

--- a/Resources/Constants.py
+++ b/Resources/Constants.py
@@ -118,6 +118,7 @@ class Constants:
         self.os_support = 12.0
         self.detected_os = 0  #        Major Kernel Version
         self.detected_os_minor = 0  #  Minor Kernel Version
+        self.allow_fv_root = False  #  Allow FileVault on broken sealed snapshots
 
         ## Boot Volume Settings
         self.firewire_boot = False  # Allow macOS FireWire Boot

--- a/Resources/Utilities.py
+++ b/Resources/Utilities.py
@@ -135,13 +135,19 @@ def amfi_status():
         return False
     return True
 
+def check_oclp_boot():
+    if get_nvram("OCLP-Version", "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102", decode=False):
+        return True
+    else:
+        return False
+
 
 def patching_status(os_sip, os):
     # Detection for Root Patching
-    sip_enabled = True  # System Integrity Protection
-    sbm_enabled = True  # Secure Boot Status (SecureBootModel)
+    sip_enabled = True  #  System Integrity Protection
+    sbm_enabled = True  #  Secure Boot Status (SecureBootModel)
     amfi_enabled = True  # Apple Mobile File Integrity
-    fv_enabled = True  # FileVault
+    fv_enabled = True  #   FileVault
     dosdude_patched = True
 
     gen6_kext = "/System/Library/Extension/AppleIntelHDGraphics.kext"
@@ -155,7 +161,8 @@ def patching_status(os_sip, os):
     if get_nvram("csr-active-config", decode=False) and csr_decode(get_nvram("csr-active-config", decode=False), os_sip) is False:
         sip_enabled = False
 
-    if os > Constants.Constants().catalina:
+    if os > Constants.Constants().catalina and not check_oclp_boot():
+        # Assume non-OCLP Macs do not have our APFS seal patch
         fv_status: str = subprocess.run("fdesetup status".split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode()
         if "FileVault is Off" in fv_status:
             fv_enabled = False

--- a/docs/BENIFITS.md
+++ b/docs/BENIFITS.md
@@ -7,7 +7,7 @@ With OpenCore Legacy Patcher we recommend users go through the below table to un
 | Features | [OpenCore Legacy Patcher](https://github.com/dortania/OpenCore-Legacy-Patcher/) | [Patched Sur](https://github.com/BenSova/Patched-Sur) |
 | :--- | :--- | :--- |
 | Over The Air Updates | <span style="color:#30BCD5">Native System Preferences, additionally supports Deltas (~2GB) for Metal GPUs</span> | <span style="color:red">Inside Patcher Sur app (~12GB), only available when InstallAssistants release.</span> InstallAssistants generally available same day as System Preference updates, however developer betas will lag behind by 1 day compared to OTAs |
-| FileVault | <span style="color:#30BCD5">Supported on Metal GPUs</span> | <span style="color:red">Not supported</span> |
+| FileVault | <span style="color:#30BCD5">Fully supported on all machines</span> | <span style="color:red">Not supported</span> |
 | System Integrity Protection | <span style="color:#30BCD5">Fully enabled on Metal GPUs</span> | <span style="color:red">Disabled for early 2013 and older during the patching process and first boot afterwards, otherwise enabled</span> |
 | APFS Snapshots | <span style="color:#30BCD5">Fully enabled</span> | <span style="color:red">Disabled</span> |
 | User facing | <span style="color:red">TUI interface</span> | <span style="color:#30BCD5">SwiftUI interface, more user friendly</span> |

--- a/docs/MONTEREY-DROP.md
+++ b/docs/MONTEREY-DROP.md
@@ -47,7 +47,7 @@ Below is a list of hardware that currently has issues with Monterey:
 * Intel HD4000 iGPUs lost support
   * Re-introduced with OpenCore Legacy Patcher v0.1.7
 
-By default these machines require root volume patches to gain graphics acceleration in Monterey. OpenCore Legacy Patcher supports readding support however SIP and FileVault can no longer be enabled due to root patching:
+By default these machines require root volume patches to gain graphics acceleration in Monterey. OpenCore Legacy Patcher supports readding support however SIP can no longer be enabled due to root patching:
 
 * Macmini6,x
 * MacBookAir5,x

--- a/payloads/Config/config.plist
+++ b/payloads/Config/config.plist
@@ -1032,6 +1032,36 @@
 				<key>Skip</key>
 				<integer>0</integer>
 			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>x86_64</string>
+				<key>Base</key>
+				<string>_apfs_filevault_allowed</string>
+				<key>Comment</key>
+				<string>Force FileVault on Broken Seal</string>
+				<key>Count</key>
+				<integer>0</integer>
+				<key>Enabled</key>
+				<false/>
+				<key>Find</key>
+				<data></data>
+				<key>Identifier</key>
+				<string>com.apple.filesystems.apfs</string>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data></data>
+				<key>MaxKernel</key>
+				<string></string>
+				<key>MinKernel</key>
+				<string>20.4.0</string>
+				<key>Replace</key>
+				<data>uAEAAADD</data>
+				<key>ReplaceMask</key>
+				<data></data>
+				<key>Skip</key>
+				<integer>0</integer>
+			</dict>
 		</array>
 		<key>Quirks</key>
 		<dict>


### PR DESCRIPTION
This feature is experimental, keep all data backed up as more validation is done.

## Current notes

* Require macOS 11.3 or newer
* MacPro5,1, MacBookPro8,2 and MacBookPro9,2 verified working
* iMac8,1 failed to boot after encryption
   * Affected on Monterey Beta 6
   * Currently researching failure reason

| Big Sur 11.5.1 (20G80, MacBookPro8,2) | Monterey Beta 6 (21A5506j, MacBookPro8,2) |
| :--- | :--- |
| ![Screen Shot 2021-09-12 at 11 15 04 AM](https://user-images.githubusercontent.com/48863253/132997198-eb7e54dd-1c1a-4d47-87e8-853a51735f31.png) | ![Screen Shot 2021-09-12 at 3 29 42 PM](https://user-images.githubusercontent.com/48863253/132997202-c6d2604d-7b0e-4b3e-93b9-c20212e9c641.png) 

| Monterey Beta 6 (21A5506j, MacPro5,1) |
| :--- |
| ![](https://user-images.githubusercontent.com/48863253/132998360-bef69d28-34a4-4d7e-aaf0-f3b250d8245e.png) |


