### PR TITLE
Update Big Sur+ Hackintosh SIP instructions

### DIFF
--- a/Resources/SysPatch.py
+++ b/Resources/SysPatch.py
@@ -650,7 +650,7 @@ set million colour before rebooting"""
             sip_value = "For Hackintoshes, please set csr-active-config to '03060000' (0x603)\nFor non-OpenCore Macs, please run 'csrutil disable' in RecoveryOS"
         else:
             sip_value = (
-                "For Hackintoshes, please set csr-active-config to '030A0000' (0xA03)\nFor non-OpenCore Macs, please run 'csrutil disable' and \n'csrutil authenticated-root disable' in RecoveryOS"
+                "For Hackintoshes, please set csr-active-config to '030E0000' (0xE03)\nFor non-OpenCore Macs, please run 'csrutil disable' and \n'csrutil authenticated-root disable' in RecoveryOS"
             )
         self.sip_enabled, self.sbm_enabled, self.amfi_enabled, self.fv_enabled, self.dosdude_patched = Utilities.patching_status(sip, self.constants.detected_os)
         if self.sip_enabled is True:


### PR DESCRIPTION
I believe this is correct to include required CSR_ALLOW_EXECUTABLE_POLICY_OVERRIDE in the instructions text, as per the bits which are actually checked for in the code.