### PR TITLE
Disable Library Validation Enforcement 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   - Applicable for BCM94328, BCM94322 and Atheros chipsets
 - Add Legacy Bluetooth support for Monterey
   - Applicable for BRCM2046 and BRCM2070 chipsets
+- Disable Library Validation allowing for AMFI usage
+  - Remove reliance on amfi_get_out_of_my_way=1
 
 ## 0.2.4
 

--- a/OCLP-CLI.command
+++ b/OCLP-CLI.command
@@ -48,7 +48,7 @@ class OpenCoreLegacyPatcher:
         parser.add_argument("--firewire", help="Enable FireWire Booting", action="store_true", required=False)
         parser.add_argument("--nvme", help="Enable NVMe Booting", action="store_true", required=False)
         parser.add_argument("--wlan", help="Enable Wake on WLAN support", action="store_true", required=False)
-        parser.add_argument("--disable_amfi", help="Disable AMFI", action="store_true", required=False)
+        # parser.add_argument("--disable_amfi", help="Disable AMFI", action="store_true", required=False)
         parser.add_argument("--moderate_smbios", help="Moderate SMBIOS Patching", action="store_true", required=False)
         parser.add_argument("--moj_cat_accel", help="Allow Root Patching on Mojave and Catalina", action="store_true", required=False)
         parser.add_argument("--disable_thunderbolt", help="Disable Thunderbolt on 2013-2014 MacBook Pros", action="store_true", required=False)
@@ -115,9 +115,9 @@ class OpenCoreLegacyPatcher:
         if args.nvme:
             print("- Set NVMe Boot configuration")
             self.constants.nvme_boot = True
-        if args.disable_amfi:
-            print("- Set Disable AMFI configuration")
-            self.constants.amfi_status = False
+        # if args.disable_amfi:
+        #     print("- Set Disable AMFI configuration")
+        #     self.constants.amfi_status = False
         if args.wlan:
             print("- Set Wake on WLAN configuration")
             self.constants.enable_wake_on_wlan = True
@@ -194,19 +194,13 @@ If you plan to create the USB for another machine, please select the "Change Mod
             self.unpatch_vol()
 
     def set_defaults(self, model, host_is_target):
+        if host_is_target:
+            if Utilities.check_metal_support(device_probe, self.computer) is False:
+                self.constants.disable_cs_lv = True
+        elif model in ModelArray.LegacyGPU:
+            self.constants.disable_cs_lv = True
         if model in ModelArray.LegacyGPU:
-            if (
-                host_is_target
-                and self.computer.dgpu
-                and self.computer.dgpu.arch
-                in [
-                    device_probe.AMD.Archs.Legacy_GCN,
-                    device_probe.AMD.Archs.Polaris,
-                    device_probe.AMD.Archs.Vega,
-                    device_probe.AMD.Archs.Navi,
-                    device_probe.NVIDIA.Archs.Kepler,
-                ]
-            ):
+            if Utilities.check_metal_support(device_probe, self.computer) is True:
                 print("- Detected Metal GPU, overriding default configuration")
                 # Building on device and we have a native, supported GPU
                 self.constants.sip_status = True
@@ -226,7 +220,7 @@ If you plan to create the USB for another machine, please select the "Change Mod
                 self.constants.secure_status = False  # Modified root volume
                 self.constants.allow_fv_root = True  #  Allow FileVault on broken seal
                 # self.constants.amfi_status = True  #  Signed bundles, Don't need to explicitly set currently
-        if model == "MacBook8,1" and host_is_target:
+        if model == "MacBook8,1":
             # MacBook8,1 has an odd bug where it cannot install Monterey with Minimal spoofing
             self.constants.serial_settings == "Moderate"
 

--- a/Resources/Build.py
+++ b/Resources/Build.py
@@ -670,9 +670,12 @@ class BuildOpenCore:
             print("- Disabling SIP")
             self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["csr-active-config"] = binascii.unhexlify("EF0F0000")
             self.config["NVRAM"]["Delete"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"] += ["csr-active-config"]
-        if self.constants.amfi_status is False:
-            print("- Disabling AMFI")
-            self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " amfi_get_out_of_my_way=1"
+        # if self.constants.amfi_status is False:
+        #     print("- Disabling AMFI")
+        #     self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]["boot-args"] += " amfi_get_out_of_my_way=1"
+        if self.constants.disable_cs_lv is True:
+            print("- Disabling Library Validation")
+            self.get_item_by_kv(self.config["Kernel"]["Patch"], "Comment", "Disable Library Validation Enforcement")["Enabled"] = True
         if self.constants.secure_status is False:
             print("- Disabling SecureBootModel")
             self.config["Misc"]["Security"]["SecureBootModel"] = "Disabled"

--- a/Resources/Constants.py
+++ b/Resources/Constants.py
@@ -115,6 +115,7 @@ class Constants:
         self.sip_status = True  #      System Integrity Protection
         self.secure_status = False  #  Secure Boot Model
         self.vault = False  #          EFI Vault
+        self.disable_cs_lv = False  #  Disable Library validation
 
         ## OS Settings
         self.os_support = 12.0

--- a/Resources/SysPatch.py
+++ b/Resources/SysPatch.py
@@ -422,10 +422,11 @@ set million colour before rebooting"""
             )
             Utilities.process_status(self.elevated(["chmod", "755", f"{self.mount_lauchd}/IOHID-Fixup.plist"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
             Utilities.process_status(self.elevated(["chown", "root:wheel", f"{self.mount_lauchd}/IOHID-Fixup.plist"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
-        else:
+        elif Utilities.check_oclp_boot() is False:
+            # Assume non-OCLP Macs don't have _cs_require_lv
             print("- Disabling Library Validation")
             Utilities.process_status(
-                self.elevated(["defaults", "write", "/Library/Preferences/com.apple.security.libraryvalidation.plist", "-bool", "true"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                self.elevated(["defaults", "write", "/Library/Preferences/com.apple.security.libraryvalidation.plist", "DisableLibraryValidation", "-bool", "true"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             )
 
     def gpu_accel_legacy_extended_ts2(self):

--- a/docs/ACCEL.md
+++ b/docs/ACCEL.md
@@ -65,6 +65,10 @@ Currently Zoom relies partially on Metal and so needs a small binary patch. Dosd
 
 ## Unable to grant special permissions to apps (ie. Camera Access to Zoom)
 
+With version 0.2.5, this issue should be full resolved
+
+::: details 0.2.4 and older Work-Around
+
 Due to the usage of `amfi_get_out_of_my_way=1`, macOS will fail to prompt users for special permissions upon application start as well as omit the entires in System Preferences. To work around this, we recommend users install [tccplus](https://github.com/jslegendre/tccplus) to manage permissions.
 
 Example usage with Discord and microphone permissions:
@@ -87,6 +91,8 @@ $ sudo sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT or RE
 
 $ sudo sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT or REPLACE INTO access VALUES('kTCCServiceCamera','us.zoom.xos',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1541440109);"
 ```
+
+:::
 
 ## Keyboard Backlight broken
 

--- a/payloads/Config/config.plist
+++ b/payloads/Config/config.plist
@@ -1062,6 +1062,36 @@
 				<key>Skip</key>
 				<integer>0</integer>
 			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>x86_64</string>
+				<key>Base</key>
+				<string>_cs_require_lv</string>
+				<key>Comment</key>
+				<string>Disable Library Validation Enforcement</string>
+				<key>Count</key>
+				<integer>0</integer>
+				<key>Enabled</key>
+				<false/>
+				<key>Find</key>
+				<data></data>
+				<key>Identifier</key>
+				<string>kernel</string>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data></data>
+				<key>MaxKernel</key>
+				<string></string>
+				<key>MinKernel</key>
+				<string>18.0.0</string>
+				<key>Replace</key>
+				<data>uAAAAADD</data>
+				<key>ReplaceMask</key>
+				<data></data>
+				<key>Skip</key>
+				<integer>0</integer>
+			</dict>
 		</array>
 		<key>Quirks</key>
 		<dict>


### PR DESCRIPTION
This PR's goal is to remove our reliance on `amfi_get_out_of_my_way=0x1` by disabling Library Validation Enforcement within XNU itself (`_cs_require_lv`):

* https://opensource.apple.com/source/xnu/xnu-7195.141.2/osfmk/kern/cs_blobs.h.auto.html
* https://opensource.apple.com/source/xnu/xnu-7195.141.2/bsd/kern/kern_cs.c.auto.html

This would allow for users to use the native Security and Privacy pane as well as uphold a much higher security standard for all OCLP users.