### PR TITLE
clarify that 0.3.0 is not yet released via WIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OpenCore Legacy Patcher changelog
 
-## 0.3.0
+## [WIP] 0.3.0 
 - Fix Nvidia Tesla Acceleration in Monterey Beta 7+
   - Add missing NVDAStartup
 - Allow configuring GMUX usage for Windows


### PR DESCRIPTION
Some have been confused about why it appears that 0.3.0 has been released via sharing of the changelog screenshot, etc. It would make sense to keep a WIP tag on things like this so folks aren't confused.