### PR TITLE
Update UNINSTALL.md

### DIFF
--- a/docs/UNINSTALL.md
+++ b/docs/UNINSTALL.md
@@ -12,4 +12,4 @@ To remove OpenCore is actually quite simply:
 
 * [Reset NVRAM or PRAM on your Mac](https://support.apple.com/HT204063)
 
-Know that if you are on Big Sur when you remove the EFI folder, your Mac will no longer boot and show the prohibited symbol. Be ready to install an older version of macOS before you uninstall OpenCore.
+Know that if you are using only an unsupported macOS on your Mac (like Big Sur or Monterey depending on your hardware) when you remove the EFI folder, your Mac will no longer boot and show the prohibited symbol. Be ready to install an older version of macOS before you uninstall OpenCore.


### PR DESCRIPTION
clarify the consequence of using any unsupported macOS version without OpenCore EFI on disk 
(in fact this applies to all currently and technically (un)supported versions like Mojave, Catalina, Big Sur, and Monterey)

Feel free to find a better wording. Not sure if I really hit the point.