### PR TITLE
Resolve Local Installer Detection

### DIFF
--- a/resources/installer.py
+++ b/resources/installer.py
@@ -23,14 +23,35 @@ def list_local_macOS_installers():
                         app_sdk = plist["DTSDKBuild"]
                     except KeyError:
                         app_sdk = "Unknown"
-                    # Check if App Version is Catalina or older
-                    if not app_version.startswith("10."):
+
+                    # app_version can sometimes report GM instead of the actual version
+                    # This is a workaround to get the actual version
+                    if app_version.startswith("GM"):
+                        try:
+                            app_version = int(app_sdk[:2])
+                            if app_version < 20:
+                                app_version = f"10.{app_version - 4}"
+                            else:
+                                app_version = f"{app_version - 9}.0"
+                        except ValueError:
+                            app_version = "Unknown"
+                    # Check if App Version is High Sierra or newer
+                    can_add = False
+                    if app_version.startswith("10."):
+                        app_sub_version = app_version.split(".")[1]
+                        if int(app_sub_version) >= 13:
+                            can_add = True
+                        else:
+                            can_add = False
+                    else:
+                        can_add = True
+                    if can_add is True:
                         application_list.update({
                             application: {
-                                "Short Name": clean_name,
-                                "Version": app_version,
-                                "Build": app_sdk,
-                                "Path": application,
+                            "Short Name": clean_name,
+                            "Version": app_version,
+                            "Build": app_sdk,
+                            "Path": application,
                             }
                         })
                 except KeyError:

--- a/resources/installer.py
+++ b/resources/installer.py
@@ -23,18 +23,22 @@ def list_local_macOS_installers():
                         app_sdk = plist["DTSDKBuild"]
                     except KeyError:
                         app_sdk = "Unknown"
-                    application_list.update({
-                        application: {
-                            "Short Name": clean_name,
-                            "Version": app_version,
-                            "Build": app_sdk,
-                            "Path": application,
-                        }
-                    })
+                    # Check if App Version is Catalina or older
+                    if not app_version.startswith("10."):
+                        application_list.update({
+                            application: {
+                                "Short Name": clean_name,
+                                "Version": app_version,
+                                "Build": app_sdk,
+                                "Path": application,
+                            }
+                        })
                 except KeyError:
                     pass
         except PermissionError:
             pass
+    # Sort Applications by version
+    application_list = {k: v for k, v in sorted(application_list.items(), key=lambda item: item[1]["Version"])}
     return application_list
 
 def create_installer(installer_path, volume_name):


### PR DESCRIPTION
* Works around PermissionError issues on `StartLauncher.app` and similar
* Sorts Installer Versions from oldest to newest
* Strips 10.12 and older installers
  * Were never properly supported previously , avoid user creation
* Attempts version resolving on GM builds

Closes https://github.com/dortania/OpenCore-Legacy-Patcher/issues/909