### PR TITLE
Work-around createinstallmedia erroring with 12.4+ installers

### DIFF
--- a/Build-Binary.command
+++ b/Build-Binary.command
@@ -123,6 +123,9 @@ class create_binary:
             if file.name in delete_files:
                 print(f"  - Deleting {file.name}")
                 file.unlink()
+            elif (Path(file) / Path("Contents/Resources/createinstallmedia")).exists():
+                print(f"  - Deleting {file}")
+                subprocess.run(["rm", "-rf", file])
 
     def download_resources(self):
         patcher_support_pkg_version = constants.Constants().patcher_support_pkg_version

--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -1872,7 +1872,6 @@ class wx_python_gui:
             self.pulse_alternative(self.progress_bar)
             wx.GetApp().Yield()
 
-        self.progress_bar.SetValue(0)
         if self.prepare_result is True:
             self.progress_label.SetLabel("Bytes Written: 0")
             self.progress_label.Centre(wx.HORIZONTAL)
@@ -1887,6 +1886,7 @@ class wx_python_gui:
             self.download_thread = threading.Thread(target=self.download_and_unzip_pkg)
             self.download_thread.start()
             default_output = float(utilities.monitor_disk_output(disk))
+            self.progress_bar.SetValue(0)
             while True:
                 time.sleep(0.1)
                 output = float(utilities.monitor_disk_output(disk))

--- a/resources/installer.py
+++ b/resources/installer.py
@@ -332,6 +332,8 @@ def list_disk_to_format():
         })
     return list_disks
 
+# Create global tmp directory
+tmp_dir = tempfile.TemporaryDirectory()
 
 def generate_installer_creation_script(tmp_location, installer_path, disk):
     # Creates installer.sh to be piped to OCLP-Helper and run as admin
@@ -352,8 +354,13 @@ def generate_installer_creation_script(tmp_location, installer_path, disk):
 
     # Create a new tmp directory
     # Our current one is a disk image, thus CoW will not work
-    ia_tmp = tempfile.mkdtemp()
+    global tmp_dir
+    ia_tmp = tmp_dir.name
+
     print(f"Creating temporary directory at {ia_tmp}")
+    # Delete all files in tmp_dir
+    for file in Path(ia_tmp).glob("*"):
+        subprocess.run(["rm", "-rf", str(file)])
 
     # Copy installer to tmp (use CoW to avoid extra disk writes)
     subprocess.run(["cp", "-cR", installer_path, ia_tmp])

--- a/resources/installer.py
+++ b/resources/installer.py
@@ -354,8 +354,8 @@ def generate_installer_creation_script(tmp_location, installer_path, disk):
         if (Path(file) / Path("Contents/Resources/createinstallmedia")).exists():
             subprocess.run(["rm", "-rf", file])
 
-    # Copy installer to tmp
-    subprocess.run(["cp", "-R", installer_path, tmp_location])
+    # Copy installer to tmp (use CoW to avoid extra disk writes)
+    subprocess.run(["cp", "-cR", installer_path, tmp_location])
 
     # Adjust installer_path to point to the copied installer
     installer_path = Path(tmp_location) / Path(Path(installer_path).name)


### PR DESCRIPTION
Following bug is applicable on native Macs, even when invoking `createinstallmedia` directly via terminal. This looks to be an Apple/Sandboxing bug, seems applicable to any host OS (ie. High Sierra through Monterey observed)
```
Failed to extract AssetData/boot/Firmware/Manifests/InstallerBoot/* from update bundle
```
Determined copying the application from `/Applications` should help resolve this error. We've implemented a temporary directory (relying on Copy on Write) to host the installer while we run our processes.
