### PR TITLE
sys_patch: Allow KDK-less root patching on Intel iGPUs and Nvidia Kepler

### DIFF
--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -196,7 +196,7 @@ def SystemPatchDictionary(os_major, os_minor, non_metal_os_support):
                 },
             },
 
-            "Metal 1 Common": {
+            "Metal 3802 Common": {
                 "Display Name": "",
                 "OS Support": {
                     "Minimum OS Support": {

--- a/resources/main.py
+++ b/resources/main.py
@@ -49,7 +49,9 @@ class OpenCoreLegacyPatcher:
 
         # Now that we have commit info, update nightly link
         if self.constants.commit_info[0] != "Running from source":
-            self.constants.installer_pkg_url_nightly = self.constants.installer_pkg_url_nightly.replace("main", self.constants.commit_info[0])
+            branch = self.constants.commit_info[0]
+            branch = branch.replace("refs/heads/", "")
+            self.constants.installer_pkg_url_nightly = self.constants.installer_pkg_url_nightly.replace("main", branch)
 
         defaults.generate_defaults.probe(self.computer.real_model, True, self.constants)
 

--- a/resources/main.py
+++ b/resources/main.py
@@ -47,6 +47,10 @@ class OpenCoreLegacyPatcher:
         self.constants.unpack_thread.start()
         self.constants.commit_info = commit_info.commit_info(self.constants.launcher_binary).generate_commit_info()
 
+        # Now that we have commit info, update nightly link
+        if self.constants.commit_info[0] != "Running from source":
+            self.constants.installer_pkg_url_nightly = self.constants.installer_pkg_url_nightly.replace("main", self.constants.commit_info[0])
+
         defaults.generate_defaults.probe(self.computer.real_model, True, self.constants)
 
         if utilities.check_cli_args() is not None:

--- a/resources/sys_patch.py
+++ b/resources/sys_patch.py
@@ -32,6 +32,7 @@
 # This is because Apple removed on-disk binaries (ref: https://github.com/dortania/OpenCore-Legacy-Patcher/issues/998)
 #   'sudo ditto /Library/Developer/KDKs/<KDK Version>/System /System/Volumes/Update/mnt1/System'
 
+import plistlib
 import shutil
 import subprocess
 from pathlib import Path
@@ -59,6 +60,8 @@ class PatchSysVolume:
             hardware_details = sys_patch_detect.detect_root_patch(self.computer.real_model, self.constants).detect_patch_set()
         self.hardware_details = hardware_details
         self.init_pathing(custom_root_mount_path=None, custom_data_mount_path=None)
+
+        self.skip_root_kmutil_requirement = self.hardware_details["Settings: Supports Auxiliary Cache"]
 
     def __del__(self):
         # Ensures that each time we're patching, we're using a clean repository
@@ -106,6 +109,8 @@ class PatchSysVolume:
         return False
 
     def merge_kdk_with_root(self):
+        if self.skip_root_kmutil_requirement is True:
+            return
         if self.constants.detected_os < os_data.os_data.ventura:
             return
         if (Path(self.mount_location) / Path("System/Library/Extensions/System.kext/PlugIns/Libkern.kext/Libkern")).exists():
@@ -149,8 +154,23 @@ class PatchSysVolume:
                 print("\nPlease reboot the machine for patches to take effect")
 
     def rebuild_snapshot(self):
-        print("- Rebuilding Kernel Cache (This may take some time)")
+        if self.rebuild_kernel_collection() is True:
+            self.update_preboot_kernel_cache()
+            self.rebuild_dyld_shared_cache()
+            if self.create_new_apfs_snapshot() is True:
+                print("- Patching complete")
+                print("\nPlease reboot the machine for patches to take effect")
+                if self.needs_kmutil_exemptions is True:
+                    print("Note: Apple will require you to open System Preferences -> Security to allow the new kernel extensions to be loaded")
+                self.constants.root_patcher_succeeded = True
+                if self.constants.gui_mode is False:
+                    input("\nPress [ENTER] to continue")
 
+    def rebuild_kernel_collection(self):
+        if self.skip_root_kmutil_requirement is True:
+            return True
+
+        print("- Rebuilding Kernel Cache (This may take some time)")
         if self.constants.detected_os > os_data.os_data.catalina:
             args = [
                 "kmutil",
@@ -206,18 +226,10 @@ class PatchSysVolume:
             print("\nPlease reboot the machine to avoid potential issues rerunning the patcher")
             if self.constants.gui_mode is False:
                 input("Press [ENTER] to continue")
-        else:
-            print("- Successfully built new kernel cache")
-            self.update_preboot_kernel_cache()
-            self.rebuild_dyld_shared_cache()
-            if self.create_new_apfs_snapshot() is True:
-                print("- Patching complete")
-                print("\nPlease reboot the machine for patches to take effect")
-                if self.needs_kmutil_exemptions is True:
-                    print("Note: Apple will require you to open System Preferences -> Security to allow the new kernel extensions to be loaded")
-                self.constants.root_patcher_succeeded = True
-                if self.constants.gui_mode is False:
-                    input("\nPress [ENTER] to continue")
+            return False
+
+        print("- Successfully built new kernel cache")
+        return True
 
     def create_new_apfs_snapshot(self):
         if self.root_supports_snapshot is True:
@@ -279,6 +291,46 @@ class PatchSysVolume:
                 utilities.process_status(utilities.elevated(["rm", destination_path_file], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
             utilities.process_status(utilities.elevated(["cp", f"{self.constants.payload_path}/{file_name}", destination_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
 
+    def add_auxkc_support(self, install_file, source_folder_path, install_patch_directory, destination_folder_path):
+        # In macOS Ventura, KDKs are required to build new Boot and System KCs
+        # However for some patch sets, we're able to use the Auxiliary KCs with '/Library/Extensions'
+
+        # kernelmanagerd determines which kext is installed by their 'OSBundleRequired' entry
+        # If a kext is labeled as 'OSBundleRequired: Root' or 'OSBundleRequired: Safe Boot',
+        # kernelmanagerd will require the kext to be installed in the Boot/SysKC
+
+        # Additionally, kexts starting with 'com.apple.' are not natively allowed to be installed
+        # in the AuxKC. So we need to explicitly set our 'OSBundleRequired' to 'Auxiliary'
+
+        if self.skip_root_kmutil_requirement is False:
+            return destination_folder_path
+        if not install_file.endswith(".kext"):
+            return destination_folder_path
+        if install_patch_directory != "/System/Library/Extensions":
+            return destination_folder_path
+        if self.constants.detected_os < os_data.os_data.ventura:
+            return destination_folder_path
+
+        updated_install_location = str(self.mount_location_data) + "/Library/Extensions"
+
+        print(f"- Adding AuxKC support to {install_file}")
+        plist_path = Path(Path(source_folder_path) / Path(install_file) / Path("Contents/Info.plist"))
+        plist_data = plistlib.load((plist_path).open("rb"))
+
+        # Check if we need to update the 'OSBundleRequired' entry
+        if not plist_data["CFBundleIdentifier"].startswith("com.apple."):
+            return updated_install_location
+        if "OSBundleRequired" in plist_data:
+            if plist_data["OSBundleRequired"] == "Auxiliary":
+                return updated_install_location
+
+        plist_data["OSBundleRequired"] = "Auxiliary"
+        plistlib.dump(plist_data, plist_path.open("wb"))
+
+        self.constants.needs_to_open_preferences = True
+
+        return updated_install_location
+
     def patch_root_vol(self):
         print(f"- Running patches for {self.model}")
         if self.patch_set_dictionary != {}:
@@ -316,6 +368,7 @@ class PatchSysVolume:
                                 if install_patch_directory == "/Library/Extensions":
                                     self.needs_kmutil_exemptions = True
                                 destination_folder_path = str(self.mount_location_data) + install_patch_directory
+                            destination_folder_path = self.add_auxkc_support(install_file, source_folder_path, install_patch_directory, destination_folder_path)
                             self.install_new_file(source_folder_path, destination_folder_path, install_file)
 
             if "Processes" in required_patches[patch]:


### PR DESCRIPTION
As mentioned in the issue #998, macOS Ventura no longer ships on-disk kernel extensions. Instead requiring Kernel Debug Kits to be installed manually. This creates numerous issues including:

* Breaking support for automatic root volume patching (ie. `AutoPkg-Assets.pkg`)
* Relies on manually uploaded KDKs (Apple has been known to go week+ without seeding a KDK)
* Requires Apple Developer Account to download (Free accounts supported, however cannot be easily automated for patcher)

Thus this PR's goal is to try and use Apple's Auxiliary Kernel Collection system (AuxKC), and install kexts to `/Library/Extensions`. This allows for patching without a KDK present, however there are some caveats:

* Each kext's Info.plist will need to be patched
  * `kernelmanagerd` currently restricts Apple kexts inside the AuxKC unless they have an explicit `Auxiliary` load requirement. OCLP will validate and patch the kext accordingly
* Auxiliary Cache usage is only beneficial for systems that need to add kexts, not delete or replace
  * Intel IGPUs and Nvidia Kepler don't need to delete/replace any kexts, however AMD GCN (and non-Metal in the future) need to replace/delete kexts present in the Boot and System Kernel Collections

Thus this PR will only be beneficial for Intel iGPUs and Nvidia Kepler, this should suffice for the majority of our user base however more research will be needed for developing a work-around to KDK's requirement on AMD GCN