### PR TITLE
Enhancement - Enable OpenCL on NVIDIA WebDriver cards

### DIFF
--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -602,7 +602,7 @@ class SystemPatchDictionary():
                         },
                         "/System/Library/PrivateFrameworks": {
                             # Restore OpenCL by adding missing compiler files
-                            "GPUCompiler.framework": "11.6" if os_data.os_conversion.is_os_newer(os_data.os_data.monterey, 0, self.os_major, self.os_minor) else {},
+                            **({ "GPUCompiler.framework": "11.6"} if os_data.os_conversion.is_os_newer(os_data.os_data.monterey, 0, self.os_major, self.os_minor) else {}),
                         },
                     },
                     "Install Non-Root": {

--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -601,7 +601,8 @@ class SystemPatchDictionary():
                             "GeForceTeslaVADriverWeb.bundle": "WebDriver-387.10.10.10.40.140",
                         },
                         "/System/Library/PrivateFrameworks": {
-                            "GPUCompiler.framework": "11.6",
+                            # Restore OpenCL by adding missing compiler files
+                            "GPUCompiler.framework": "11.6" if os_data.os_conversion.is_os_newer(os_data.os_data.monterey, 0, self.os_major, self.os_minor) else {},
                         },
                     },
                     "Install Non-Root": {

--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -600,6 +600,9 @@ class SystemPatchDictionary():
                             "GeForceTeslaGLDriverWeb.bundle": "WebDriver-387.10.10.10.40.140",
                             "GeForceTeslaVADriverWeb.bundle": "WebDriver-387.10.10.10.40.140",
                         },
+                        "/System/Library/PrivateFrameworks": {
+                            "GPUCompiler.framework": "11.6",
+                        },
                     },
                     "Install Non-Root": {
                         "/Library/Extensions": {


### PR DESCRIPTION
This PR enables OpenCL functionality on the following GPU architectures:

- NVIDIA Fermi
- NVIDIA Maxwell
- NVIDIA Pascal

Tested and working well on my GTX 1050Ti:
https://browser.geekbench.com/v6/compute/338216
![Screenshot_2023-04-17_at_6 27 01_PM](https://user-images.githubusercontent.com/75343012/232625951-96118329-945a-4bf4-8eed-84a877a3587f.png)
![Screenshot_2023-04-17_at_6 28 26_PM](https://user-images.githubusercontent.com/75343012/232625956-58ba9492-1764-4659-ad95-0ad6527251e7.png)
