### PR TITLE
Enhancement - Enable USB 3 expansion card support on Legacy USB 1.1 machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Update 3802 Patchset Binaries:
   - Resolves additional 3rd party app crashes on Metal with macOS 13.3+
   - ex: PowerPoint's "Presentation Mode"
+- Allow for coexistence of USB 3.0 controllers and USB 1.1 patches on macOS 13+
+  - Restores USB 3.0 expansion card support on USB 1.1 machines such as MacPro5,1
 - Resolve OpenCL rendering on Nvidia Web Drivers
   - thanks [@jazzzny](https://github.com/Jazzzny)
 - Increment Binaries:

--- a/resources/sys_patch/sys_patch_detect.py
+++ b/resources/sys_patch/sys_patch_detect.py
@@ -477,11 +477,10 @@ class DetectRootPatch:
         if self.constants.detected_os < os_data.os_data.ventura:
             return False
 
-        for controller in self.constants.computer.usb_controllers:
-            if (isinstance(controller, device_probe.XHCIController)):
-                # Currently USB 1.1 patches are incompatible with USB 3.0 controllers
-                # TODO: Downgrade remaining USB stack to ensure full support
-                return False
+        # Former USB 1.1 Patches used to be incompatible with XHCI controllers
+        #for controller in self.constants.computer.usb_controllers:
+            #if (isinstance(controller, device_probe.XHCIController)):
+                #return False
 
         # If we're on a hackintosh, check for UHCI/OHCI controllers
         if self.constants.host_is_hackintosh is True:


### PR DESCRIPTION
This PR disables the USB 3.0 blacklist found in the USB 1.1 patch detection, as the new USB 1.1 patches are compatible with PCIe USB 3.0 chips from Fresco Logic and AsMedia. This resolves USB 3 expansion card support on machines such as MacPro5,1.

Tested and working well with my FL1100 and MacPro5,1:
![Screenshot_2023-04-18_at_4 50 18_PM](https://user-images.githubusercontent.com/75343012/232904835-1ae99c22-5a80-4d31-86b5-707bc46d75fd.png)
