### PR TITLE
Enhancement - Add a ColorSync downgrade toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - Restores USB 3.0 expansion card support on USB 1.1 machines such as MacPro5,1
 - Resolve OpenCL rendering on Nvidia Web Drivers
   - thanks [@jazzzny](https://github.com/Jazzzny)
+- Implement option to disable ColorSync downgrade on HD 3000 Macs
+  - Allows for Display Profiles support
 - Increment Binaries:
   - PatcherSupportPkg 0.9.6 - release
 

--- a/resources/constants.py
+++ b/resources/constants.py
@@ -210,6 +210,7 @@ class Constants:
         self.set_content_caching:    bool = False  # Set Content Caching
         self.disable_xcpm:           bool = False  # Disable XCPM (X86PlatformPlugin.kext)
         self.set_vmm_cpuid:          bool = False  # Set VMM bit inside CPUID
+        self.disable_cat_colorsync:  bool = False  # Disable the ColorSync patch to regain Display Profiles
         self.set_alc_usage:          bool = True  #  Set AppleALC usage
         self.allow_3rd_party_drives: bool = True  #  Allow ThridPartyDrives quirk
         self.allow_nvme_fixing:      bool = True  #  Allow NVMe Kernel Space Patches

--- a/resources/defaults.py
+++ b/resources/defaults.py
@@ -71,6 +71,14 @@ class GenerateDefaults:
                 global_settings.GlobalEnviromentSettings().write_property("MacBookPro_TeraScale_2_Accel", False)
                 self.constants.allow_ts2_accel = False
 
+        if self.model in ["MacBookAir4,1","MacBookAir4,2","MacBookPro8,1","MacBookPro8,2","MacBookPro8,3","Macmini5,1"]:
+            colorsync_status = global_settings.GlobalEnviromentSettings().read_property("Disable_ColorSync_Downgrade")
+            if colorsync_status is True:
+                self.constants.disable_cat_colorsync = True
+            else:
+                global_settings.GlobalEnviromentSettings().write_property("Disable_ColorSync_Downgrade", False)
+                self.constants.disable_cat_colorsync = False
+
         if self.model in smbios_data.smbios_dictionary:
             if smbios_data.smbios_dictionary[self.model]["CPU Generation"] >= cpu_data.cpu_data.skylake.value:
                 # On 2016-2017 MacBook Pros, 15" devices used a stock Samsung SSD with IONVMeController

--- a/resources/gui/gui_main.py
+++ b/resources/gui/gui_main.py
@@ -3157,9 +3157,11 @@ class wx_python_gui:
     def disable_colorsync_click(self, event=None):
         if self.set_colorsync_checkbox.GetValue():
             logging.info("ColorSync Patch Disabled")
+            global_settings.GlobalEnviromentSettings().write_property("Disable_ColorSync_Downgrade", True)
             self.constants.disable_cat_colorsync = True
         else:
             logging.info("ColorSync Patch Enabled")
+            global_settings.GlobalEnviromentSettings().write_property("Disable_ColorSync_Downgrade", False)
             self.constants.disable_cat_colorsync = False
 
     def force_web_drivers_click(self, event=None):

--- a/resources/gui/gui_main.py
+++ b/resources/gui/gui_main.py
@@ -3156,10 +3156,10 @@ class wx_python_gui:
 
     def disable_colorsync_click(self, event=None):
         if self.set_colorsync_checkbox.GetValue():
-            logging.info("ColorSync Patch Enabled")
+            logging.info("ColorSync Patch Disabled")
             self.constants.disable_cat_colorsync = True
         else:
-            logging.info("ColorSync Patch Disabled")
+            logging.info("ColorSync Patch Enabled")
             self.constants.disable_cat_colorsync = False
 
     def force_web_drivers_click(self, event=None):

--- a/resources/gui/gui_main.py
+++ b/resources/gui/gui_main.py
@@ -2853,13 +2853,25 @@ class wx_python_gui:
             self.set_terascale_accel_checkbox.Disable()
             self.set_terascale_accel_checkbox.SetValue(False)
 
+        # Disable ColorSync Downgrade
+        self.set_colorsync_checkbox = wx.CheckBox(self.frame_modal, label="Disable ColorSync Downgrade")
+        self.set_colorsync_checkbox.SetValue(self.constants.disable_cat_colorsync)
+        self.set_colorsync_checkbox.Bind(wx.EVT_CHECKBOX, self.disable_colorsync_click)
+        self.set_colorsync_checkbox.SetPosition(wx.Point(
+            self.set_terascale_accel_checkbox.GetPosition().x,
+            self.set_terascale_accel_checkbox.GetPosition().y + self.set_terascale_accel_checkbox.GetSize().height))
+        self.set_colorsync_checkbox.SetToolTip(wx.ToolTip("This option will disable the ColorSync patch used on HD 3000 Macs.\nMainly applicable if you need Display Profile functionality"))
+        if self.computer.real_model not in ["MacBookAir4,1","MacBookAir4,2","MacBookPro8,1","MacBookPro8,2","MacBookPro8,3","Macmini5,1"]:
+            self.set_colorsync_checkbox.Disable()
+            self.set_colorsync_checkbox.SetValue(False)
+
         # Windows GMUX
         self.windows_gmux_checkbox = wx.CheckBox(self.frame_modal, label="Windows GMUX")
         self.windows_gmux_checkbox.SetValue(self.constants.dGPU_switch)
         self.windows_gmux_checkbox.Bind(wx.EVT_CHECKBOX, self.windows_gmux_click)
         self.windows_gmux_checkbox.SetPosition(wx.Point(
-            self.set_terascale_accel_checkbox.GetPosition().x,
-            self.set_terascale_accel_checkbox.GetPosition().y + self.set_terascale_accel_checkbox.GetSize().height))
+            self.set_colorsync_checkbox.GetPosition().x,
+            self.set_colorsync_checkbox.GetPosition().y + self.set_colorsync_checkbox.GetSize().height))
         self.windows_gmux_checkbox.SetToolTip(wx.ToolTip("Enable this option to allow usage of the hardware GMUX to switch between Intel and Nvidia/AMD GPUs in Windows."))
 
         # Hibernation Workaround
@@ -3141,6 +3153,14 @@ class wx_python_gui:
             logging.info("TS2 Acceleration Disabled")
             global_settings.GlobalEnviromentSettings().write_property("MacBookPro_TeraScale_2_Accel", False)
             self.constants.allow_ts2_accel = False
+
+    def disable_colorsync_click(self, event=None):
+        if self.set_colorsync_checkbox.GetValue():
+            logging.info("ColorSync Patch Enabled")
+            self.constants.disable_cat_colorsync = True
+        else:
+            logging.info("ColorSync Patch Disabled")
+            self.constants.disable_cat_colorsync = False
 
     def force_web_drivers_click(self, event=None):
         if self.force_web_drivers_checkbox.GetValue():

--- a/resources/sys_patch/sys_patch_generate.py
+++ b/resources/sys_patch/sys_patch_generate.py
@@ -53,8 +53,7 @@ class GenerateRootPatchSets:
             required_patches.update({"WebKit Monterey Common": all_hardware_patchset["Graphics"]["WebKit Monterey Common"]})
             required_patches.update({"Intel Sandy Bridge": all_hardware_patchset["Graphics"]["Intel Sandy Bridge"]})
             # Patchset breaks Display Profiles, don't install if primary GPU is AMD
-            if self.constants.computer.real_model not in ["Macmini5,2", "iMac12,1", "iMac12,2"]:
-                required_patches.update({"Non-Metal ColorSync Workaround": all_hardware_patchset["Graphics"]["Non-Metal ColorSync Workaround"]})
+
 
         if self.hardware_details["Graphics: Intel Ivy Bridge"] is True:
             required_patches.update({"Metal 3802 Common": all_hardware_patchset["Graphics"]["Metal 3802 Common"]})

--- a/resources/sys_patch/sys_patch_generate.py
+++ b/resources/sys_patch/sys_patch_generate.py
@@ -52,8 +52,9 @@ class GenerateRootPatchSets:
             required_patches.update({"High Sierra GVA": all_hardware_patchset["Graphics"]["High Sierra GVA"]})
             required_patches.update({"WebKit Monterey Common": all_hardware_patchset["Graphics"]["WebKit Monterey Common"]})
             required_patches.update({"Intel Sandy Bridge": all_hardware_patchset["Graphics"]["Intel Sandy Bridge"]})
-            # Patchset breaks Display Profiles, don't install if primary GPU is AMD
-
+            # Patchset breaks Display Profiles, don't install if primary GPU is AMD. Give users option to disable patch in settings to restore Display Profiles
+            if self.constants.computer.real_model not in ["Macmini5,2", "iMac12,1", "iMac12,2"] or self.constants.disable_cat_colorsync is False:
+                required_patches.update({"Non-Metal ColorSync Workaround": all_hardware_patchset["Graphics"]["Non-Metal ColorSync Workaround"]})
 
         if self.hardware_details["Graphics: Intel Ivy Bridge"] is True:
             required_patches.update({"Metal 3802 Common": all_hardware_patchset["Graphics"]["Metal 3802 Common"]})


### PR DESCRIPTION
Multiple users have requested a way to change Display Profiles on HD 3000 machines with the ColorSync downgrade, so this PR adds a checkbox under developer settings which allows users to disable the ColorSync patch. Kept off by default, only disables the patch if a user enables the checkbox. Additionally, the checkbox is only enabled on systems that can use the patch, similar to the TS2 checkbox.

<img width="215" alt="Screenshot 2023-04-21 at 1 14 26 PM" src="https://user-images.githubusercontent.com/75343012/233696234-71786154-c152-4601-893f-6df4b1afc9d7.png">

