### PR TITLE
Enhancement - Restore Photo Booth App on Non-Metal Macs running macOS Monterey and newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Update non-Metal Binaries:
   - Resolves cryptexd and sshd crashes
   - Resolves screen recording regression
+  - Resolves Photo Booth on macOS Monterey and later
 - Resolve Application alias not being created with AutoPatcher
 - Backend changes:
   - Rename OCLP-Helper to OpenCore-Patcher

--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -103,6 +103,9 @@ class SystemPatchDictionary():
                             "GPUSupport.framework": "10.14.3",
                             "SkyLight.framework":  f"10.14.6-{self.os_major}",
                         },
+                        "/System/Applications": {
+                            **({ "Photo Booth.app": "11.7.6"} if self.os_major >= os_data.os_data.monterey else {}),
+                        },
                     },
                     "Remove": {
                         "/System/Library/Extensions": [


### PR DESCRIPTION
This PR restores the Photo Booth app on Non-Metal Macs running Monterey+ by downgrading the app to Big Sur's version. Tested thoroughly, and no issues were noticed.

This PR also requires an addition to PatcherSupportPkg, under Universal-Binaries -> 11.7.6 -> System -> Applications:
https://github.com/dortania/PatcherSupportPkg/pull/11

![Screenshot_2023-05-22_at_1 39 26_PM](https://github.com/dortania/OpenCore-Legacy-Patcher/assets/75343012/18b0f69f-0ac4-48b6-8e92-f8268b16a74e)
