### PR TITLE
Quality of Life - Add workaround for MenuBar2 crashing after patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Allows for Live Text support on systems with3802 GPUs
     - ie. Intel Ivy Bridge and Haswell, Nvidia Kepler
   - Previously disabled due to high instability in Photos with Face Scanning, now resolved
+- Resolve crashing after patching with MenuBar2 implementation enabled
 - Backend changes:
   - Call `setpgrp()` to prevent app from being killed if parent process is killed (ie. LaunchAgents)
   - Resolve payloads path being mis-routed during CLI calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - ie. Intel Ivy Bridge and Haswell, Nvidia Kepler
   - Previously disabled due to high instability in Photos with Face Scanning, now resolved
 - Resolve crashing after patching with MenuBar2 implementation enabled
+  - Setting must be re-enabled after patching
 - Backend changes:
   - Call `setpgrp()` to prevent app from being killed if parent process is killed (ie. LaunchAgents)
   - Resolve payloads path being mis-routed during CLI calls

--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -148,7 +148,7 @@ class SystemPatchDictionary():
                         "defaults write /Library/Preferences/.GlobalPreferences.plist InternalDebugUseGPUProcessForCanvasRenderingEnabled -bool false": True,
                         "defaults write /Library/Preferences/.GlobalPreferences.plist WebKitExperimentalUseGPUProcessForCanvasRenderingEnabled -bool false": True,
                         # MenuBar2 breaks macOS if enabled before patching
-                        "defaults write -g Amy.MenuBar2Beta -bool false": True,
+                        "defaults write ~/Library/Preferences/.GlobalPreferences.plist Amy.MenuBar2Beta -bool false": True,
 
                     },
                 },

--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -148,7 +148,7 @@ class SystemPatchDictionary():
                         "defaults write /Library/Preferences/.GlobalPreferences.plist InternalDebugUseGPUProcessForCanvasRenderingEnabled -bool false": True,
                         "defaults write /Library/Preferences/.GlobalPreferences.plist WebKitExperimentalUseGPUProcessForCanvasRenderingEnabled -bool false": True,
                         # MenuBar2 breaks macOS if enabled before patching
-                        "defaults write ~/Library/Preferences/.GlobalPreferences.plist Amy.MenuBar2Beta -bool false": True,
+                        "defaults write /Library/Preferences/.GlobalPreferences.plist Amy.MenuBar2Beta -bool false": True,
                     },
                 },
                 "Non-Metal IOAccelerator Common": {

--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -147,6 +147,9 @@ class SystemPatchDictionary():
                         **({"defaults write /Library/Preferences/.GlobalPreferences.plist ShowDate -int 1": True } if self.os_float >= self.macOS_12_4 else {}),
                         "defaults write /Library/Preferences/.GlobalPreferences.plist InternalDebugUseGPUProcessForCanvasRenderingEnabled -bool false": True,
                         "defaults write /Library/Preferences/.GlobalPreferences.plist WebKitExperimentalUseGPUProcessForCanvasRenderingEnabled -bool false": True,
+                        # MenuBar2 breaks macOS if enabled before patching
+                        "defaults write -g Amy.MenuBar2Beta -bool false": True,
+
                     },
                 },
                 "Non-Metal IOAccelerator Common": {

--- a/data/sys_patch_dict.py
+++ b/data/sys_patch_dict.py
@@ -149,7 +149,6 @@ class SystemPatchDictionary():
                         "defaults write /Library/Preferences/.GlobalPreferences.plist WebKitExperimentalUseGPUProcessForCanvasRenderingEnabled -bool false": True,
                         # MenuBar2 breaks macOS if enabled before patching
                         "defaults write ~/Library/Preferences/.GlobalPreferences.plist Amy.MenuBar2Beta -bool false": True,
-
                     },
                 },
                 "Non-Metal IOAccelerator Common": {


### PR DESCRIPTION
This PR disables MenuBar2 during the patching process, as having MenuBar2 enabled before patching breaks macOS.