### PR TITLE
Developer - Add buttons to mount and save the root volume

### DIFF
--- a/resources/sys_patch/sys_patch.py
+++ b/resources/sys_patch/sys_patch.py
@@ -417,9 +417,11 @@ class PatchSysVolume:
         """
         Unmount root volume
         """
-
-        logging.info("- Unmounting Root Volume (Don't worry if this fails)")
-        utilities.elevated(["diskutil", "unmount", self.root_mount_path], stdout=subprocess.PIPE).stdout.decode().strip().encode()
+        if self.root_mount_path:
+            logging.info("- Unmounting Root Volume (Don't worry if this fails)")
+            utilities.elevated(["diskutil", "unmount", self.root_mount_path], stdout=subprocess.PIPE).stdout.decode().strip().encode()
+        else:
+            logging.info("- Skipping Root Volume unmount")
 
 
     def _rebuild_dyld_shared_cache(self) -> None:

--- a/resources/sys_patch/sys_patch.py
+++ b/resources/sys_patch/sys_patch.py
@@ -279,6 +279,8 @@ class PatchSysVolume:
                 if self.needs_kmutil_exemptions is True:
                     logging.info("Note: Apple will require you to open System Preferences -> Security to allow the new kernel extensions to be loaded")
                 self.constants.root_patcher_succeeded = True
+                return True
+        return False
 
 
     def _rebuild_kernel_collection(self) -> bool:

--- a/resources/wx_gui/gui_settings.py
+++ b/resources/wx_gui/gui_settings.py
@@ -7,6 +7,7 @@ import subprocess
 import os
 
 from pathlib import Path
+from resources.sys_patch.sys_patch import PatchSysVolume
 
 from resources.wx_gui import (
     gui_support,
@@ -1306,7 +1307,6 @@ Hardware Information:
         if os.geteuid() != 0:
             wx.MessageDialog(self.parent, "Please relaunch as Root to mount the Root Volume", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
         else:
-            from resources.sys_patch.sys_patch import PatchSysVolume
             #Don't need to pass model as we're bypassing all logic
             if PatchSysVolume("",self.constants)._mount_root_vol() == True:
                 wx.MessageDialog(self.parent, "Root Volume Mounted, remember to fix permissions before saving the Root Volume", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
@@ -1317,7 +1317,6 @@ Hardware Information:
         if os.geteuid() != 0:
             wx.MessageDialog(self.parent, "Please relaunch as Root to save changes", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
         else:
-            from resources.sys_patch.sys_patch import PatchSysVolume
             #Don't need to pass model as we're bypassing all logic
             if PatchSysVolume("",self.constants)._rebuild_root_volume() == True:
                 wx.MessageDialog(self.parent, "Root Volume saved, please reboot to apply changes", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()

--- a/resources/wx_gui/gui_settings.py
+++ b/resources/wx_gui/gui_settings.py
@@ -858,7 +858,7 @@ class SettingsFrame(wx.Frame):
                 "wrap_around 2": {
                     "type": "wrap_around",
                 },
-                "Update Root Volume": {
+                "Save Root Volume": {
                     "type": "button",
                     "function": self.on_bless_root_vol,
                     "description": [
@@ -1309,7 +1309,7 @@ Hardware Information:
             from resources.sys_patch.sys_patch import PatchSysVolume
             #Don't need to pass model as we're bypassing all logic
             if PatchSysVolume("",self.constants)._mount_root_vol() == True:
-                wx.MessageDialog(self.parent, "Root Volume Mounted, remember to fix permissions before blessing 🙏", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
+                wx.MessageDialog(self.parent, "Root Volume Mounted, remember to fix permissions before saving the Root Volume", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
             else:
                 wx.MessageDialog(self.parent, "Root Volume Mount Failed, check terminal output", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
 
@@ -1321,7 +1321,7 @@ Hardware Information:
             #Don't need to pass model as we're bypassing all logic
             if PatchSysVolume("",self.constants)._rebuild_kernel_collection() == True:
                 if PatchSysVolume("",self.constants)._create_new_apfs_snapshot() == True:
-                    wx.MessageDialog(self.parent, "Root Volume Updated, please reboot to apply changes", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
+                    wx.MessageDialog(self.parent, "Root Volume saved, please reboot to apply changes", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
                 else:
                     wx.MessageDialog(self.parent, "Root Volume Bless Failed, check terminal output", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
             else:

--- a/resources/wx_gui/gui_settings.py
+++ b/resources/wx_gui/gui_settings.py
@@ -1319,10 +1319,7 @@ Hardware Information:
         else:
             from resources.sys_patch.sys_patch import PatchSysVolume
             #Don't need to pass model as we're bypassing all logic
-            if PatchSysVolume("",self.constants)._rebuild_kernel_collection() == True:
-                if PatchSysVolume("",self.constants)._create_new_apfs_snapshot() == True:
-                    wx.MessageDialog(self.parent, "Root Volume saved, please reboot to apply changes", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
-                else:
-                    wx.MessageDialog(self.parent, "Root Volume Bless Failed, check terminal output", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
+            if PatchSysVolume("",self.constants)._rebuild_root_volume() == True:
+                wx.MessageDialog(self.parent, "Root Volume saved, please reboot to apply changes", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
             else:
-                wx.MessageDialog(self.parent, "KC Update Failed, check terminal output", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
+                wx.MessageDialog(self.parent, "Root Volume update Failed, check terminal output", "Error", wx.OK | wx.ICON_ERROR).ShowModal()

--- a/resources/wx_gui/gui_settings.py
+++ b/resources/wx_gui/gui_settings.py
@@ -4,6 +4,7 @@ import pprint
 import logging
 import py_sip_xnu
 import subprocess
+import os
 
 from pathlib import Path
 
@@ -814,6 +815,9 @@ class SettingsFrame(wx.Frame):
                 },
             },
             "Developer": {
+                "Validation": {
+                    "type": "title",
+                },
                 "Install latest nightly build 🧪": {
                     "type": "button",
                     "function": self.on_nightly,
@@ -837,6 +841,28 @@ class SettingsFrame(wx.Frame):
                     "function": self.on_export_constants,
                     "description": [
                         "Export constants.py values to a txt file.",
+                    ],
+                },
+                "Developer Root Volume Patching": {
+                    "type": "title",
+                },
+                "Mount Root Volume": {
+                    "type": "button",
+                    "function": self.on_mount_root_vol,
+                    "description": [
+                        "Life's too short to type 'sudo mount -o",
+                        "nobrowse -t apfs /dev/diskXsY",
+                        "/System/Volumes/Update/mnt1' every time.",
+                    ],
+                },
+                "wrap_around 2": {
+                    "type": "wrap_around",
+                },
+                "Update Root Volume": {
+                    "type": "button",
+                    "function": self.on_bless_root_vol,
+                    "description": [
+                        "Rebuild kernel cache and bless snapshot 🙏",
                     ],
                 },
             },
@@ -1275,3 +1301,28 @@ Hardware Information:
 
     def on_test_exception(self, event: wx.Event) -> None:
         raise Exception("Test Exception")
+    
+    def on_mount_root_vol(self, event: wx.Event) -> None:
+        if os.geteuid() != 0:
+            wx.MessageDialog(self.parent, "Please relaunch as Root to mount the Root Volume", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
+        else:
+            from resources.sys_patch.sys_patch import PatchSysVolume
+            #Don't need to pass model as we're bypassing all logic
+            if PatchSysVolume("",self.constants)._mount_root_vol() == True:
+                wx.MessageDialog(self.parent, "Root Volume Mounted, remember to fix permissions before blessing 🙏", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
+            else:
+                wx.MessageDialog(self.parent, "Root Volume Mount Failed, check terminal output", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
+
+    def on_bless_root_vol(self, event: wx.Event) -> None:
+        if os.geteuid() != 0:
+            wx.MessageDialog(self.parent, "Please relaunch as Root to save changes", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
+        else:
+            from resources.sys_patch.sys_patch import PatchSysVolume
+            #Don't need to pass model as we're bypassing all logic
+            if PatchSysVolume("",self.constants)._rebuild_kernel_collection() == True:
+                if PatchSysVolume("",self.constants)._create_new_apfs_snapshot() == True:
+                    wx.MessageDialog(self.parent, "Root Volume Updated, please reboot to apply changes", "Success", wx.OK | wx.ICON_INFORMATION).ShowModal()
+                else:
+                    wx.MessageDialog(self.parent, "Root Volume Bless Failed, check terminal output", "Error", wx.OK | wx.ICON_ERROR).ShowModal()
+            else:
+                wx.MessageDialog(self.parent, "KC Update Failed, check terminal output", "Error", wx.OK | wx.ICON_ERROR).ShowModal()


### PR DESCRIPTION
This PR adds buttons in the Developer menu to mount and save the root volume. This saves a lot of time for maintainers and contributors as the alternative is to run several long commands. Tested and working, though please review


<img width="536" alt="Screenshot 2023-07-28 at 9 29 36 PM" src="https://github.com/dortania/OpenCore-Legacy-Patcher/assets/75343012/219ba9c9-ecc3-46c3-bc19-131a957be5f7">