### PR TITLE
Add a warning when launching application on Hackintosh systems

### DIFF
--- a/resources/wx_gui/gui_main_menu.py
+++ b/resources/wx_gui/gui_main_menu.py
@@ -175,7 +175,7 @@ class MainFrame(wx.Frame):
             elif button_name == "Support":
                 if self.constants.host_is_hackintosh is True:
                     button.Disable()
-                    description_label.SetLabel("No support is provided for Hackintoshes.\nDo NOT ask for community support.")
+                    description_label.SetLabel("No support is provided for Hackintoshes.\nDo not ask for community support.")
 
             index += 1
             if index == rollover:

--- a/resources/wx_gui/gui_main_menu.py
+++ b/resources/wx_gui/gui_main_menu.py
@@ -172,6 +172,10 @@ class MainFrame(wx.Frame):
                 button.SetSize((100, -1))
                 button.Centre(wx.HORIZONTAL)
                 description_label.Centre(wx.HORIZONTAL)
+            elif button_name == "Support":
+                if self.constants.host_is_hackintosh is True:
+                    button.Disable()
+                    description_label.SetLabel("No support is provided for Hackintoshes.\nDo NOT ask for community support.")
 
             index += 1
             if index == rollover:
@@ -211,11 +215,11 @@ class MainFrame(wx.Frame):
             self.SetTitle(self.title)
             pop_up_hack = wx.MessageDialog(
                 self,
-                f"OpenCore Legacy Patcher does not offer support for, nor guarantees the compatibility of its patchset with Hackintosh systems.\n\nPlease refrain from reporting issues to GitHub or the community Discord.",
+                f"OpenCore Legacy Patcher does not offer support for, nor guarantees the compatibility of its patchset with Hackintosh systems.\n\nDO NOT report issues to GitHub or the community Discord.",
                 "Hackintosh Detected",
                 style=wx.YES_NO | wx.ICON_EXCLAMATION
             )
-            pop_up_hack.SetYesNoLabels("I understand", "Exit")
+            pop_up_hack.SetYesNoLabels("I will not ask for support", "Exit")
             if pop_up_hack.ShowModal() == wx.ID_NO:
                 sys.exit()
             return

--- a/resources/wx_gui/gui_main_menu.py
+++ b/resources/wx_gui/gui_main_menu.py
@@ -219,7 +219,7 @@ class MainFrame(wx.Frame):
                 "Hackintosh Detected",
                 style=wx.YES_NO | wx.ICON_EXCLAMATION
             )
-            pop_up_hack.SetYesNoLabels("I will not ask for support", "Exit")
+            pop_up_hack.SetYesNoLabels("OK", "Exit")
             if pop_up_hack.ShowModal() == wx.ID_NO:
                 sys.exit()
             return

--- a/resources/wx_gui/gui_main_menu.py
+++ b/resources/wx_gui/gui_main_menu.py
@@ -207,7 +207,8 @@ class MainFrame(wx.Frame):
             return
 
         if self.constants.host_is_hackintosh is True:
-            self.SetTitle(f"{self.title} - UNSUPPORTED")
+            self.title += " - UNSUPPORTED"
+            self.SetTitle(self.title)
             pop_up_hack = wx.MessageDialog(
                 self,
                 f"OpenCore Legacy Patcher does not offer support for, nor guarantees the compatibility of its patchset with Hackintosh systems.\n\nPlease refrain from reporting issues to GitHub or the community Discord.",

--- a/resources/wx_gui/gui_main_menu.py
+++ b/resources/wx_gui/gui_main_menu.py
@@ -206,6 +206,20 @@ class MainFrame(wx.Frame):
             self.on_build_and_install()
             return
 
+        if self.constants.host_is_hackintosh is False:
+            self.title += " - UNSUPPORTED"
+            self.SetTitle(self.title)
+            pop_up_hack = wx.MessageDialog(
+                self,
+                f"OpenCore Legacy Patcher does not offer support for, nor guarantees the compatibility of its patchset with Hackintosh systems.\n\nPlease refrain from reporting issues to GitHub or the community Discord.",
+                "Hackintosh Detected",
+                style=wx.YES_NO | wx.ICON_EXCLAMATION
+            )
+            pop_up_hack.SetYesNoLabels("I understand", "Exit")
+            if pop_up_hack.ShowModal() == wx.ID_NO:
+                sys.exit()
+            return
+
         self._fix_local_install()
 
         if "--update_installed" in sys.argv and self.constants.has_checked_updates is False and gui_support.CheckProperties(self.constants).host_can_build():

--- a/resources/wx_gui/gui_main_menu.py
+++ b/resources/wx_gui/gui_main_menu.py
@@ -207,8 +207,7 @@ class MainFrame(wx.Frame):
             return
 
         if self.constants.host_is_hackintosh is True:
-            self.title += " - UNSUPPORTED"
-            self.SetTitle(self.title)
+            self.SetTitle(f"{self.title} - UNSUPPORTED")
             pop_up_hack = wx.MessageDialog(
                 self,
                 f"OpenCore Legacy Patcher does not offer support for, nor guarantees the compatibility of its patchset with Hackintosh systems.\n\nPlease refrain from reporting issues to GitHub or the community Discord.",

--- a/resources/wx_gui/gui_main_menu.py
+++ b/resources/wx_gui/gui_main_menu.py
@@ -206,7 +206,7 @@ class MainFrame(wx.Frame):
             self.on_build_and_install()
             return
 
-        if self.constants.host_is_hackintosh is False:
+        if self.constants.host_is_hackintosh is True:
             self.title += " - UNSUPPORTED"
             self.SetTitle(self.title)
             pop_up_hack = wx.MessageDialog(


### PR DESCRIPTION
This PR adds a warning upon launching the application on a Hackintosh and alters the title bar.

This change does not affect OCLP's Mac user base, only providing a warning for those who wish to use the patcher on Hackintoshes.

A warning is helpful for many reasons:
1. We do not provide any community support for Hackintoshes
2. Other communities such as Hackintosh Paradise do not provide support either
3. Some Hackintosh users come to OCLP's Discord looking for support, this will prevent that
4. Helpers on the community Discord shouldn't have to deal with confusing Hackintosh-exclusive issues
5. With the upcoming release of macOS Sonoma, there may be a rise in Hackintosh users potentially using OCLP