### PR TITLE
Refactor subprocess usage

### DIFF
--- a/Build-Binary.command
+++ b/Build-Binary.command
@@ -126,7 +126,7 @@ class CreateBinary:
         if Path(f"./dist/OpenCore-Patcher.app").exists():
             print("Found OpenCore-Patcher.app, removing...")
             rm_output = subprocess.run(
-                ["rm", "-rf", "./dist/OpenCore-Patcher.app"],
+                ["/bin/rm", "-rf", "./dist/OpenCore-Patcher.app"],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             if rm_output.returncode != 0:
@@ -152,11 +152,9 @@ class CreateBinary:
         print("Embedding icns...")
         for file in Path("payloads/Icon/AppIcons").glob("*.icns"):
             subprocess.run(
-                ["cp", str(file), "./dist/OpenCore-Patcher.app/Contents/Resources/"],
+                ["/bin/cp", str(file), "./dist/OpenCore-Patcher.app/Contents/Resources/"],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-
-
 
 
     def _embed_key(self):
@@ -252,12 +250,12 @@ class CreateBinary:
                 if file.name in whitelist_folders:
                     continue
                 print(f"- Deleting {file.name}")
-                subprocess.run(["rm", "-rf", file])
+                subprocess.run(["/bin/rm", "-rf", file])
             else:
                 if file.name in whitelist_files:
                     continue
                 print(f"- Deleting {file.name}")
-                subprocess.run(["rm", "-f", file])
+                subprocess.run(["/bin/rm", "-f", file])
 
 
     def _download_resources(self):
@@ -279,7 +277,7 @@ class CreateBinary:
                     assert resource, "Resource cannot be empty"
                     assert resource not in ("/", "."), "Resource cannot be root"
                     rm_output = subprocess.run(
-                        ["rm", "-rf", f"./{resource}"],
+                        ["/bin/rm", "-rf", f"./{resource}"],
                         stdout=subprocess.PIPE, stderr=subprocess.PIPE
                     )
                     if rm_output.returncode != 0:
@@ -293,7 +291,7 @@ class CreateBinary:
 
             download_result = subprocess.run(
                 [
-                    "curl", "-LO",
+                    "/usr/bin/curl", "-LO",
                     f"https://github.com/dortania/PatcherSupportPkg/releases/download/{patcher_support_pkg_version}/{resource}"
                 ],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -322,7 +320,7 @@ class CreateBinary:
 
             print("- Removing old payloads.dmg")
             rm_output = subprocess.run(
-                ["rm", "-rf", "./payloads.dmg"],
+                ["/bin/rm", "-rf", "./payloads.dmg"],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             if rm_output.returncode != 0:
@@ -332,7 +330,7 @@ class CreateBinary:
 
         print("- Generating DMG...")
         dmg_output = subprocess.run([
-            'hdiutil', 'create', './payloads.dmg',
+            '/usr/bin/hdiutil', 'create', './payloads.dmg',
             '-megabytes', '32000',  # Overlays can only be as large as the disk image allows
             '-format', 'UDZO', '-ov',
             '-volname', 'OpenCore Patcher Resources (Base)',
@@ -410,7 +408,7 @@ class CreateBinary:
         path = "./dist/OpenCore-Patcher"
         print(f"- Removing {path}")
         rm_output = subprocess.run(
-            ["rm", "-rf", path],
+            ["/bin/rm", "-rf", path],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         if rm_output.returncode != 0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # OpenCore Legacy Patcher changelog
 
 ## 1.4.0
+- Refactor subprocess invocations
 
 ## 1.3.0
 - Resolve mismatched `CFBundleExecutable` and binary name for kexts.

--- a/payloads/Kexts/Update-Kexts.command
+++ b/payloads/Kexts/Update-Kexts.command
@@ -108,36 +108,36 @@ class GenerateKexts:
         with tempfile.TemporaryDirectory() as temp_dir:
             # Download source
             weg_source_zip = f"{temp_dir}/WhateverGreen-{self.weg_version}.zip"
-            subprocess.run(["curl", "-L", weg_source_url, "-o", weg_source_zip], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["/usr/bin/curl", "--location", weg_source_url, "--output", weg_source_zip], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
             # Unzip source
-            subprocess.run(["unzip", weg_source_zip, "-d", temp_dir], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["/usr/bin/unzip", weg_source_zip, "-d", temp_dir], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
             # Git clone MacKernelSDK into source
-            subprocess.run(["git", "clone", "https://github.com/acidanthera/MacKernelSDK", f"{temp_dir}/WhateverGreen-{self.weg_version}/MacKernelSDK"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["/usr/bin/git", "clone", "https://github.com/acidanthera/MacKernelSDK", f"{temp_dir}/WhateverGreen-{self.weg_version}/MacKernelSDK"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
             # Grab latest Lilu release, debug version
             lilu_zip = f"{temp_dir}/Lilu-{self.lilu_version}-DEBUG.zip"
-            subprocess.run(["curl", "-L", lilu_url, "-o", lilu_zip], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["/usr/bin/curl", "--location", lilu_url, "--output", lilu_zip], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
             # Unzip Lilu into WEG source
-            subprocess.run(["unzip", lilu_zip, "-d", f"{temp_dir}/WhateverGreen-{self.weg_version}"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["/usr/bin/unzip", lilu_zip, "-d", f"{temp_dir}/WhateverGreen-{self.weg_version}"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
             # Apply patch
             patch_path = Path("./Acidanthera/WhateverGreen-Navi-Backlight.patch").absolute()
-            subprocess.run(["git", "apply", patch_path], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=f"{temp_dir}/WhateverGreen-{self.weg_version}")
+            subprocess.run(["/usr/bin/git", "apply", patch_path], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=f"{temp_dir}/WhateverGreen-{self.weg_version}")
 
             # Build WEG
             for variant in ["Release", "Debug"]:
-                subprocess.run(["xcodebuild", "-configuration", variant], cwd=f"{temp_dir}/WhateverGreen-{self.weg_version}", check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                subprocess.run(["/usr/bin/xcodebuild", "-configuration", variant], cwd=f"{temp_dir}/WhateverGreen-{self.weg_version}", check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
             # Zip Release
             for variant in ["RELEASE", "DEBUG"]:
                 dst_path = Path(f"./Acidanthera/WhateverGreen-v{self.weg_version}-Navi-{variant}.zip").absolute()
-                subprocess.run(["zip", "-r", dst_path, "WhateverGreen.kext"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=f"{temp_dir}/WhateverGreen-{self.weg_version}/build/{'Release' if variant == 'RELEASE' else 'Debug'}")
+                subprocess.run(["/usr/bin/zip", "-r", dst_path, "WhateverGreen.kext"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=f"{temp_dir}/WhateverGreen-{self.weg_version}/build/{'Release' if variant == 'RELEASE' else 'Debug'}")
                 if Path(f"./Acidanthera/WhateverGreen-v{self.weg_old}-Navi-{variant}.zip").exists():
-                    subprocess.run(["rm", f"./Acidanthera/WhateverGreen-v{self.weg_old}-Navi-{variant}.zip"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    subprocess.run(["/bin/rm", f"./Acidanthera/WhateverGreen-v{self.weg_old}-Navi-{variant}.zip"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         self._update_constants_file("self.whatevergreen_navi_version", f"{self.weg_old}-Navi", f"{self.weg_version}-Navi")
 
@@ -212,14 +212,14 @@ class GenerateKexts:
                 zip_name = f"{override_kext_zip_name}-v{remote_version}-{variant}.zip" if override_kext_zip_name else f"{kext_name}-v{remote_version}-{variant}.zip"
 
                 if Path(f"./{kext_folder}/{zip_name.replace(f'v{remote_version}', f'v{local_version}')}").exists():
-                    subprocess.run(["rm", "-rf", f"./{kext_folder}/{zip_name.replace(f'v{remote_version}', f'v{local_version}')}"])
+                    subprocess.run(["/bin/rm", "-rf", f"./{kext_folder}/{zip_name.replace(f'v{remote_version}', f'v{local_version}')}"])
                 self._download_file(asset["browser_download_url"], f"./{kext_folder}/{zip_name}", f"{kext_name}.kext")
                 self._update_constants_file(KEXT_DICTIONARY[kext_folder][kext_name]["Constants Variable"], local_version, remote_version)
 
                 if override_kext_zip_name:
                     # rename zip file
                     os.rename(f"./{kext_folder}/{zip_name}", f"./{kext_folder}/{kext_name}-v{remote_version}-{variant}.zip")
-                    subprocess.run(["rm", "-rf", f"./{kext_folder}/{kext_name}-v{local_version}-{variant}.zip"])
+                    subprocess.run(["/bin/rm", "-rf", f"./{kext_folder}/{kext_name}-v{local_version}-{variant}.zip"])
 
 
     def _get_local_version(self, kext_folder, kext_name, variant):
@@ -247,14 +247,14 @@ class GenerateKexts:
                 f.write(download.content)
 
             # Unzip file
-            subprocess.run(["unzip", "-q", f"{temp_dir}/temp.zip", "-d", f"{temp_dir}"], check=True)
+            subprocess.run(["/usr/bin/unzip", "-q", f"{temp_dir}/temp.zip", "-d", f"{temp_dir}"], check=True)
 
             print(f"  Moving {file} to {file_path}...")
             # Zip file
-            subprocess.run(["zip", "-q", "-r", Path(file_path).name, file], cwd=f"{temp_dir}", check=True)
+            subprocess.run(["/usr/bin/zip", "-q", "-r", Path(file_path).name, file], cwd=f"{temp_dir}", check=True)
 
             # Move file
-            subprocess.run(["mv", f"{temp_dir}/{Path(file_path).name}", file_path], check=True)
+            subprocess.run(["/bin/mv", f"{temp_dir}/{Path(file_path).name}", file_path], check=True)
 
 
     def _update_constants_file(self, variable_name, old_version, new_version):

--- a/payloads/OpenCore/Update-OpenCore.command
+++ b/payloads/OpenCore/Update-OpenCore.command
@@ -128,24 +128,24 @@ class GenerateOpenCore:
         for variant in BUILD_VARIANTS:
             print(f"Moving {variant} folder...")
             subprocess.run (
-                ["mv", f"{self.working_dir}/OpenCore-{variant}-ROOT/X64", f"{self.working_dir}/OpenCore-{variant}"],
+                ["/bin/mv", f"{self.working_dir}/OpenCore-{variant}-ROOT/X64", f"{self.working_dir}/OpenCore-{variant}"],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             if variant == "DEBUG":
                 for utility in IMPORTANT_UTILITIES:
                     print(f"Moving {utility} from {variant} variant...")
                     subprocess.run (
-                        ["rm", "-rf", f"{self.working_dir}/{utility}"],
+                        ["/bin/rm", "-rf", f"{self.working_dir}/{utility}"],
                         stdout=subprocess.PIPE, stderr=subprocess.PIPE
                     )
                     subprocess.run (
-                        ["mv", f"{self.working_dir}/OpenCore-{variant}-ROOT/Utilities/{utility}/{utility}", f"{self.working_dir}/{utility}"],
+                        ["/bin/mv", f"{self.working_dir}/OpenCore-{variant}-ROOT/Utilities/{utility}/{utility}", f"{self.working_dir}/{utility}"],
                         stdout=subprocess.PIPE, stderr=subprocess.PIPE
                     )
 
             # Remove root folder
             subprocess.run (
-                ["rm", "-rf", f"{self.working_dir}/OpenCore-{variant}-ROOT"],
+                ["/bin/rm", "-rf", f"{self.working_dir}/OpenCore-{variant}-ROOT"],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
 
@@ -153,12 +153,12 @@ class GenerateOpenCore:
         print("Removing zip files...")
         # remove debug_zip
         subprocess.run (
-            ["rm", "-rf", self.debug_zip],
+            ["/bin/rm", "-rf", self.debug_zip],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         # remove release_zip
         subprocess.run (
-            ["rm", "-rf", self.release_zip],
+            ["/bin/rm", "-rf", self.release_zip],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
@@ -194,7 +194,7 @@ class GenerateOpenCore:
             if (self.working_dir / f"OpenCore-{variant}").exists():
                 print(f"   Deleting old {variant} variant...")
                 subprocess.run (
-                    ["rm", "-rf", f"{self.working_dir}/OpenCore-{variant}"],
+                    ["/bin/rm", "-rf", f"{self.working_dir}/OpenCore-{variant}"],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE
                 )
 
@@ -212,7 +212,7 @@ class GenerateOpenCore:
         # Create S/L/C
         print("   Creating SLC folder")
         subprocess.run (
-            ["mkdir", "-p", f"{self.working_dir}/OpenCore-{variant}/System/Library/CoreServices"],
+            ["/bin/mkdir", "-p", f"{self.working_dir}/OpenCore-{variant}/System/Library/CoreServices"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
@@ -220,21 +220,21 @@ class GenerateOpenCore:
         print("   Relocating BOOT folder to SLC")
         for file in (self.working_dir / f"OpenCore-{variant}/EFI/BOOT").iterdir():
             subprocess.run (
-                ["mv", f"{file}", f"{self.working_dir}/OpenCore-{variant}/System/Library/CoreServices"],
+                ["/bin/mv", f"{file}", f"{self.working_dir}/OpenCore-{variant}/System/Library/CoreServices"],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
 
         # Rename BOOTx64.efi to boot.efi
         print("   Renaming BOOTx64.efi to boot.efi")
         subprocess.run (
-            ["mv", f"{self.working_dir}/OpenCore-{variant}/System/Library/CoreServices/BOOTx64.efi", f"{self.working_dir}/OpenCore-{variant}/System/Library/CoreServices/boot.efi"],
+            ["/bin/mv", f"{self.working_dir}/OpenCore-{variant}/System/Library/CoreServices/BOOTx64.efi", f"{self.working_dir}/OpenCore-{variant}/System/Library/CoreServices/boot.efi"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
         # Delete BOOT folder
         print("   Deleting BOOT folder")
         subprocess.run (
-            ["rm", "-rf", f"{self.working_dir}/OpenCore-{variant}/EFI/BOOT"],
+            ["/bin/rm", "-rf", f"{self.working_dir}/OpenCore-{variant}/EFI/BOOT"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
@@ -244,7 +244,7 @@ class GenerateOpenCore:
             if Path(f"{self.working_dir}/OpenCore-{variant}/EFI/OC/Drivers/{driver}").exists():
                 print(f"      Deleting {driver}")
                 subprocess.run (
-                    ["rm", f"{self.working_dir}/OpenCore-{variant}/EFI/OC/Drivers/{driver}"],
+                    ["/bin/rm", f"{self.working_dir}/OpenCore-{variant}/EFI/OC/Drivers/{driver}"],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE
                 )
             else:
@@ -256,7 +256,7 @@ class GenerateOpenCore:
             if Path(f"{self.working_dir}/OpenCore-{variant}/EFI/OC/Tools/{tool}").exists():
                 print(f"      Deleting {tool}")
                 subprocess.run (
-                    ["rm", f"{self.working_dir}/OpenCore-{variant}/EFI/OC/Tools/{tool}"],
+                    ["/bin/rm", f"{self.working_dir}/OpenCore-{variant}/EFI/OC/Tools/{tool}"],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE
                 )
             else:
@@ -265,21 +265,21 @@ class GenerateOpenCore:
         # Rename OpenCore-<variant> to OpenCore-Build
         print("   Renaming OpenCore folder")
         subprocess.run (
-            ["mv", f"{self.working_dir}/OpenCore-{variant}", f"{self.working_dir}/OpenCore-Build"],
+            ["/bin/mv", f"{self.working_dir}/OpenCore-{variant}", f"{self.working_dir}/OpenCore-Build"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
         # Create OpenCore-<variant>.zip
         print("   Creating OpenCore.zip")
         subprocess.run (
-            ["ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", f"{self.working_dir}/OpenCore-Build", f"{self.working_dir}/OpenCore-{variant}.zip"],
+            ["/usr/bin/ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", f"{self.working_dir}/OpenCore-Build", f"{self.working_dir}/OpenCore-{variant}.zip"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
         # Delete OpenCore-Build
         print("   Deleting OpenCore-Build")
         subprocess.run (
-            ["rm", "-rf", f"{self.working_dir}/OpenCore-Build"],
+            ["/bin/rm", "-rf", f"{self.working_dir}/OpenCore-Build"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 

--- a/resources/arguments.py
+++ b/resources/arguments.py
@@ -124,7 +124,7 @@ class arguments:
         """
         Fetch KDK for incoming OS
         """
-        results = subprocess.run(["ps", "-ax"], stdout=subprocess.PIPE)
+        results = subprocess.run(["/bin/ps", "-ax"], stdout=subprocess.PIPE)
         if results.stdout.decode("utf-8").count("OpenCore-Patcher --cache_os") > 1:
             logging.info("Another instance of OS caching is running, exiting")
             return
@@ -154,7 +154,7 @@ class arguments:
             if "GPUCompanionBundles" not in kext_plist:
                 continue
             logging.info(f"  - Removing {kext.name}")
-            subprocess.run(["rm", "-rf", kext])
+            subprocess.run(["/bin/rm", "-rf", kext])
 
 
     def _build_handler(self) -> None:

--- a/resources/build/smbios.py
+++ b/resources/build/smbios.py
@@ -288,7 +288,7 @@ class BuildSMBIOS:
         """
 
         if self.constants.custom_serial_number == "" or self.constants.custom_board_serial_number == "":
-            macserial_output = subprocess.run([self.constants.macserial_path] + f"-g -m {self.spoofed_model} -n 1".split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            macserial_output = subprocess.run([self.constants.macserial_path, "--generate", "--model", self.spoofed_model, "--num", "1"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             macserial_output = macserial_output.stdout.decode().strip().split(" | ")
             sn = macserial_output[0]
             mlb = macserial_output[1]

--- a/resources/defaults.py
+++ b/resources/defaults.py
@@ -329,9 +329,9 @@ class GenerateDefaults:
 
                 for key in ["Moraea_BlurBeta"]:
                     # Enable BetaBlur if user hasn't disabled it
-                    is_key_enabled = subprocess.run(["defaults", "read", "-g", key], stdout=subprocess.PIPE).stdout.decode("utf-8").strip()
+                    is_key_enabled = subprocess.run(["/usr/bin/defaults", "read", "-globalDomain", key], stdout=subprocess.PIPE).stdout.decode("utf-8").strip()
                     if is_key_enabled not in ["false", "0"]:
-                        subprocess.run(["defaults", "write", "-g", key, "-bool", "true"])
+                        subprocess.run(["/usr/bin/defaults", "write", "-globalDomain", key, "-bool", "true"])
 
     def _check_amfipass_supported(self) -> None:
         """

--- a/resources/global_settings.py
+++ b/resources/global_settings.py
@@ -114,7 +114,7 @@ class GlobalEnviromentSettings:
             return
 
         # Set file permission to allow any user to write to log file
-        result = subprocess.run(["chmod", "777", self.global_settings_plist], capture_output=True)
+        result = subprocess.run(["/bin/chmod", "777", self.global_settings_plist], capture_output=True)
         if result.returncode != 0:
             logging.warning("Failed to fix settings file permissions:")
             if result.stderr:

--- a/resources/install.py
+++ b/resources/install.py
@@ -125,49 +125,49 @@ class tui_disk_installation:
 
         if (mount_path / Path("EFI/OC")).exists():
             logging.info("Removing preexisting EFI/OC folder")
-            subprocess.run(["rm", "-rf", mount_path / Path("EFI/OC")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/rm", "-rf", mount_path / Path("EFI/OC")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if (mount_path / Path("System")).exists():
             logging.info("Removing preexisting System folder")
-            subprocess.run(["rm", "-rf", mount_path / Path("System")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/rm", "-rf", mount_path / Path("System")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if (mount_path / Path("boot.efi")).exists():
             logging.info("Removing preexisting boot.efi")
-            subprocess.run(["rm", mount_path / Path("boot.efi")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/rm", mount_path / Path("boot.efi")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         logging.info("Copying OpenCore onto EFI partition")
-        subprocess.run(["mkdir", "-p", mount_path / Path("EFI")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        subprocess.run(["cp", "-r", self.constants.opencore_release_folder / Path("EFI/OC"), mount_path / Path("EFI/OC")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        subprocess.run(["cp", "-r", self.constants.opencore_release_folder / Path("System"), mount_path / Path("System")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(["/bin/mkdir", "-p", mount_path / Path("EFI")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(["/bin/cp", "-r", self.constants.opencore_release_folder / Path("EFI/OC"), mount_path / Path("EFI/OC")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(["/bin/cp", "-r", self.constants.opencore_release_folder / Path("System"), mount_path / Path("System")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if Path(self.constants.opencore_release_folder / Path("boot.efi")).exists():
-            subprocess.run(["cp", self.constants.opencore_release_folder / Path("boot.efi"), mount_path / Path("boot.efi")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/cp", self.constants.opencore_release_folder / Path("boot.efi"), mount_path / Path("boot.efi")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if self.constants.boot_efi is True:
             logging.info("Converting Bootstrap to BOOTx64.efi")
             if (mount_path / Path("EFI/BOOT")).exists():
-                subprocess.run(["rm", "-rf", mount_path / Path("EFI/BOOT")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                subprocess.run(["/bin/rm", "-rf", mount_path / Path("EFI/BOOT")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             Path(mount_path / Path("EFI/BOOT")).mkdir()
-            subprocess.run(["mv", mount_path / Path("System/Library/CoreServices/boot.efi"), mount_path / Path("EFI/BOOT/BOOTx64.efi")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            subprocess.run(["rm", "-rf", mount_path / Path("System")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/mv", mount_path / Path("System/Library/CoreServices/boot.efi"), mount_path / Path("EFI/BOOT/BOOTx64.efi")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/rm", "-rf", mount_path / Path("System")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if self._determine_sd_card(sd_type) is True:
             logging.info("Adding SD Card icon")
-            subprocess.run(["cp", self.constants.icon_path_sd, mount_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/cp", self.constants.icon_path_sd, mount_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         elif ssd_type is True:
             logging.info("Adding SSD icon")
-            subprocess.run(["cp", self.constants.icon_path_ssd, mount_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/cp", self.constants.icon_path_ssd, mount_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         elif disk_type == "USB":
             logging.info("Adding External USB Drive icon")
-            subprocess.run(["cp", self.constants.icon_path_external, mount_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/cp", self.constants.icon_path_external, mount_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         else:
             logging.info("Adding Internal Drive icon")
-            subprocess.run(["cp", self.constants.icon_path_internal, mount_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["/bin/cp", self.constants.icon_path_internal, mount_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         logging.info("Cleaning install location")
         if not self.constants.recovery_status:
             logging.info("Unmounting EFI partition")
-            subprocess.run(["diskutil", "umount", mount_path], stdout=subprocess.PIPE).stdout.decode().strip().encode()
+            subprocess.run(["/usr/sbin/diskutil", "umount", mount_path], stdout=subprocess.PIPE).stdout.decode().strip().encode()
 
         logging.info("OpenCore transfer complete")
 

--- a/resources/kdk_handler.py
+++ b/resources/kdk_handler.py
@@ -334,7 +334,7 @@ class KernelDebugKitObject:
         kdk_build = kdk_plist_data["ProductBuildVersion"]
 
         # Check pkg receipts for this build, will give a canonical list if all files that should be present
-        result = subprocess.run(["pkgutil", "--files", f"com.apple.pkg.KDK.{kdk_build}"], capture_output=True)
+        result = subprocess.run(["/usr/sbin/pkgutil", "--files", f"com.apple.pkg.KDK.{kdk_build}"], capture_output=True)
         if result.returncode != 0:
             # If pkg receipt is missing, we'll fallback to legacy validation
             logging.info(f"pkg receipt missing for {kdk_path.name}, falling back to legacy validation")
@@ -468,7 +468,7 @@ class KernelDebugKitObject:
             logging.warning(f"KDK does not exist: {kdk_path}")
             return
 
-        rm_args = ["rm", "-rf" if Path(kdk_path).is_dir() else "-f", kdk_path]
+        rm_args = ["/bin/rm", "-rf" if Path(kdk_path).is_dir() else "-f", kdk_path]
 
         result = utilities.elevated(rm_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if result.returncode != 0:
@@ -538,7 +538,7 @@ class KernelDebugKitObject:
             return False
 
         # TODO: should we use the checksum from the API?
-        result = subprocess.run(["hdiutil", "verify", self.constants.kdk_download_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = subprocess.run(["/usr/bin/hdiutil", "verify", self.constants.kdk_download_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode != 0:
             logging.info("Error: Kernel Debug Kit checksum verification failed!")
             logging.info(f"Output: {result.stderr.decode('utf-8')}")
@@ -612,7 +612,7 @@ class KernelDebugKitUtilities:
 
         logging.info(f"Extracting downloaded KDK disk image")
         with tempfile.TemporaryDirectory() as mount_point:
-            result = subprocess.run(["hdiutil", "attach", kdk_path, "-mountpoint", mount_point, "-nobrowse"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            result = subprocess.run(["/usr/bin/hdiutil", "attach", kdk_path, "-mountpoint", mount_point, "-nobrowse"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             if result.returncode != 0:
                 logging.info("Failed to mount KDK:")
                 logging.info(result.stdout.decode('utf-8'))
@@ -644,7 +644,7 @@ class KernelDebugKitUtilities:
         Parameters:
             mount_point (Path): Path to mount point
         """
-        subprocess.run(["hdiutil", "detach", mount_point], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        subprocess.run(["/usr/bin/hdiutil", "detach", mount_point], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
 
     def _create_backup(self, kdk_path: Path, kdk_info_plist: Path) -> None:
@@ -674,7 +674,7 @@ class KernelDebugKitUtilities:
             return
 
         if not Path(KDK_INSTALL_PATH).exists():
-            subprocess.run(["mkdir", "-p", KDK_INSTALL_PATH], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            subprocess.run(["/bin/mkdir", "-p", KDK_INSTALL_PATH], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         kdk_dst_name = f"KDK_{kdk_info_dict['version']}_{kdk_info_dict['build']}.pkg"
         kdk_dst_path = Path(f"{KDK_INSTALL_PATH}/{kdk_dst_name}")
@@ -684,7 +684,7 @@ class KernelDebugKitUtilities:
             logging.info("Backup already exists, skipping")
             return
 
-        result = utilities.elevated(["cp", "-R", kdk_path, kdk_dst_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        result = utilities.elevated(["/bin/cp", "-R", kdk_path, kdk_dst_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if result.returncode != 0:
             logging.info("Failed to create KDK backup:")
             logging.info(result.stdout.decode('utf-8'))

--- a/resources/logging_handler.py
+++ b/resources/logging_handler.py
@@ -130,7 +130,7 @@ class InitializeLoggingSupport:
         ]
 
         for path in paths:
-            result = subprocess.run(["chmod", "777", path], capture_output=True)
+            result = subprocess.run(["/bin/chmod", "777", path], capture_output=True)
             if result.returncode != 0:
                 logging.error(f"Failed to fix log file permissions")
                 if result.stdout:
@@ -251,7 +251,7 @@ class InitializeLoggingSupport:
                 return
 
             if cant_log is True:
-                subprocess.run(["open", "--reveal", self.log_filepath])
+                subprocess.run(["/usr/bin/open", "--reveal", self.log_filepath])
                 return
 
             threading.Thread(target=analytics_handler.Analytics(self.constants).send_crash_report, args=(self.log_filepath,)).start()

--- a/resources/macos_installer_handler.py
+++ b/resources/macos_installer_handler.py
@@ -108,10 +108,10 @@ class InstallerCreation():
         logging.info(f"Creating temporary directory at {ia_tmp}")
         # Delete all files in tmp_dir
         for file in Path(ia_tmp).glob("*"):
-            subprocess.run(["rm", "-rf", str(file)])
+            subprocess.run(["/bin/rm", "-rf", str(file)])
 
         # Copy installer to tmp (use CoW to avoid extra disk writes)
-        args = ["cp", "-cR", installer_path, ia_tmp]
+        args = ["/bin/cp", "-cR", installer_path, ia_tmp]
         if utilities.check_filesystem_type() != "apfs":
             # HFS+ disks do not support CoW
             args[1] = "-R"
@@ -623,7 +623,7 @@ class LocalInstallerCatalog:
 
             output = subprocess.run(
                 [
-                    "hdiutil", "attach", "-noverify", sharedsupport_path,
+                    "/usr/bin/hdiutil", "attach", "-noverify", sharedsupport_path,
                     "-mountpoint", tmpdir,
                     "-nobrowse",
                 ],
@@ -644,6 +644,6 @@ class LocalInstallerCatalog:
                         detected_os = plist["Assets"][0]["OSVersion"]
 
             # Unmount SharedSupport.dmg
-            subprocess.run(["hdiutil", "detach", tmpdir], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            subprocess.run(["/usr/bin/hdiutil", "detach", tmpdir], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         return (detected_build, detected_os)

--- a/resources/macos_installer_handler.py
+++ b/resources/macos_installer_handler.py
@@ -179,13 +179,13 @@ fi
         # TODO: AllDisksAndPartitions is not supported in Snow Leopard and older
         try:
             # High Sierra and newer
-            disks = plistlib.loads(subprocess.run("diskutil list -plist physical".split(), stdout=subprocess.PIPE).stdout.decode().strip().encode())
+            disks = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "list", "-plist", "physical"], stdout=subprocess.PIPE).stdout.decode().strip().encode())
         except ValueError:
             # Sierra and older
-            disks = plistlib.loads(subprocess.run("diskutil list -plist".split(), stdout=subprocess.PIPE).stdout.decode().strip().encode())
+            disks = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "list", "-plist"], stdout=subprocess.PIPE).stdout.decode().strip().encode())
 
         for disk in disks["AllDisksAndPartitions"]:
-            disk_info = plistlib.loads(subprocess.run(f"diskutil info -plist {disk['DeviceIdentifier']}".split(), stdout=subprocess.PIPE).stdout.decode().strip().encode())
+            disk_info = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", disk["DeviceIdentifier"]], stdout=subprocess.PIPE).stdout.decode().strip().encode())
             try:
                 all_disks[disk["DeviceIdentifier"]] = {"identifier": disk_info["DeviceNode"], "name": disk_info["MediaName"], "size": disk_info["TotalSize"], "removable": disk_info["Internal"], "partitions": {}}
             except KeyError:
@@ -407,7 +407,7 @@ class RemoteInstallerCatalog:
                 })
 
         available_apps = {k: v for k, v in sorted(available_apps.items(), key=lambda x: x[1]['Version'])}
-        
+
         return available_apps
 
 

--- a/resources/os_probe.py
+++ b/resources/os_probe.py
@@ -44,7 +44,7 @@ class OSProbe:
             str: OS version (ex. 12.0)
         """
 
-        result = subprocess.run(["sw_vers", "-productVersion"], stdout=subprocess.PIPE)
+        result = subprocess.run(["/usr/bin/sw_vers", "-productVersion"], stdout=subprocess.PIPE)
         if result.returncode != 0:
             raise RuntimeError("Failed to detect OS version")
 

--- a/resources/reroute_payloads.py
+++ b/resources/reroute_payloads.py
@@ -36,7 +36,7 @@ class RoutePayloadDiskImage:
             self._unmount_active_dmgs(unmount_all_active=False)
             output = subprocess.run(
                 [
-                    "hdiutil", "attach", "-noverify", f"{self.constants.payload_path_dmg}",
+                    "/usr/bin/hdiutil", "attach", "-noverify", f"{self.constants.payload_path_dmg}",
                     "-mountpoint", Path(self.temp_dir.name / Path("payloads")),
                     "-nobrowse",
                     "-shadow", Path(self.temp_dir.name / Path("payloads_overlay")),
@@ -67,7 +67,7 @@ class RoutePayloadDiskImage:
             unmount_all_active (bool): If True, unmount all active DMGs, otherwise only unmount our own DMG
         """
 
-        dmg_info = subprocess.run(["hdiutil", "info", "-plist"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        dmg_info = subprocess.run(["/usr/bin/hdiutil", "info", "-plist"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         dmg_info = plistlib.loads(dmg_info.stdout)
 
 
@@ -80,12 +80,12 @@ class RoutePayloadDiskImage:
                             if self.temp_dir.name in image["shadow-path"]:
                                 logging.info(f"Unmounting personal {variant}")
                                 subprocess.run(
-                                    ["hdiutil", "detach", image["system-entities"][0]["dev-entry"], "-force"],
+                                    ["/usr/bin/hdiutil", "detach", image["system-entities"][0]["dev-entry"], "-force"],
                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT
                                 )
                     else:
                         logging.info(f"Unmounting {variant} at: {image['system-entities'][0]['dev-entry']}")
                         subprocess.run(
-                            ["hdiutil", "detach", image["system-entities"][0]["dev-entry"], "-force"],
+                            ["/usr/bin/hdiutil", "detach", image["system-entities"][0]["dev-entry"], "-force"],
                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT
                         )

--- a/resources/sys_patch/sys_patch_auto.py
+++ b/resources/sys_patch/sys_patch_auto.py
@@ -170,7 +170,7 @@ Please check the Github page for more information about this release."""
                     warning_str = f"""\n\nWARNING: We're unable to verify whether there are any new releases of OpenCore Legacy Patcher on Github. Be aware that you may be using an outdated version for this OS. If you're unsure, verify on Github that OpenCore Legacy Patcher {self.constants.patcher_version} is the latest official release"""
 
                 args = [
-                    "osascript",
+                    "/usr/bin/osascript",
                     "-e",
                     f"""display dialog "OpenCore Legacy Patcher has detected you're running without Root Patches, and would like to install them.\n\nmacOS wipes all root patches during OS installs and updates, so they need to be reinstalled.\n\nFollowing Patches have been detected for your system: \n{patch_string}\nWould you like to apply these patches?{warning_str}" """
                     f'with icon POSIX file "{self.constants.app_icon_path}"',
@@ -182,7 +182,7 @@ Please check the Github page for more information about this release."""
                 )
                 if output.returncode == 0:
                     args = [
-                        "osascript",
+                        "/usr/bin/osascript",
                         "-e",
                         f'''do shell script "{args_string}"'''
                         f' with prompt "OpenCore Legacy Patcher would like to patch your root volume"'
@@ -238,7 +238,7 @@ Please check the Github page for more information about this release."""
             return True
 
         args = [
-            "osascript",
+            "/usr/bin/osascript",
             "-e",
             f"""display dialog "OpenCore Legacy Patcher has detected that you are booting {'a different' if self.constants.special_build else 'an outdated'} OpenCore build\n- Booted: {self.constants.computer.oclp_version}\n- Installed: {self.constants.patcher_version}\n\nWould you like to update the OpenCore bootloader?" """
             f'with icon POSIX file "{self.constants.app_icon_path}"',
@@ -304,7 +304,7 @@ Please check the Github page for more information about this release."""
         # Check if OpenCore is on a USB drive
         logging.info("- Boot Drive does not match macOS drive, checking if OpenCore is on a USB drive")
 
-        disk_info = plistlib.loads(subprocess.run(["diskutil", "info", "-plist", root_disk], stdout=subprocess.PIPE).stdout)
+        disk_info = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", root_disk], stdout=subprocess.PIPE).stdout)
         try:
             if disk_info["Ejectable"] is False:
                 logging.info("- Boot Disk is not removable, skipping prompt")
@@ -313,7 +313,7 @@ Please check the Github page for more information about this release."""
             logging.info("- Boot Disk is ejectable, prompting user to install to internal")
 
             args = [
-                "osascript",
+                "/usr/bin/osascript",
                 "-e",
                 f"""display dialog "OpenCore Legacy Patcher has detected that you are booting OpenCore from an USB or External drive.\n\nIf you would like to boot your Mac normally without a USB drive plugged in, you can install OpenCore to the internal hard drive.\n\nWould you like to launch OpenCore Legacy Patcher and install to disk?" """
                 f'with icon POSIX file "{self.constants.app_icon_path}"',
@@ -362,12 +362,12 @@ Please check the Github page for more information about this release."""
                     logging.info(f"  - {name} checksums match, skipping")
                     continue
                 logging.info(f"  - Existing service found, removing")
-                utilities.process_status(utilities.elevated(["rm", services[service]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+                utilities.process_status(utilities.elevated(["/bin/rm", services[service]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
             # Create parent directories
             if not Path(services[service]).parent.exists():
                 logging.info(f"  - Creating {Path(services[service]).parent} directory")
-                utilities.process_status(utilities.elevated(["mkdir", "-p", Path(services[service]).parent], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
-            utilities.process_status(utilities.elevated(["cp", service, services[service]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+                utilities.process_status(utilities.elevated(["/bin/mkdir", "-p", Path(services[service]).parent], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+            utilities.process_status(utilities.elevated(["/bin/cp", service, services[service]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
 
             # Set the permissions on the service
             utilities.process_status(utilities.elevated(["chmod", "644", services[service]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
@@ -383,33 +383,33 @@ Please check the Github page for more information about this release."""
 
         if not Path("Library/Application Support/Dortania").exists():
             logging.info("- Creating /Library/Application Support/Dortania/")
-            utilities.process_status(utilities.elevated(["mkdir", "-p", "/Library/Application Support/Dortania"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+            utilities.process_status(utilities.elevated(["/bin/mkdir", "-p", "/Library/Application Support/Dortania"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
 
         logging.info("- Copying OpenCore Patcher to /Library/Application Support/Dortania/")
         if Path("/Library/Application Support/Dortania/OpenCore-Patcher.app").exists():
             logging.info("- Deleting existing OpenCore-Patcher")
-            utilities.process_status(utilities.elevated(["rm", "-R", "/Library/Application Support/Dortania/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+            utilities.process_status(utilities.elevated(["/bin/rm", "-R", "/Library/Application Support/Dortania/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
 
         # Strip everything after OpenCore-Patcher.app
         path = str(self.constants.launcher_binary).split("/Contents/MacOS/OpenCore-Patcher")[0]
         logging.info(f"- Copying {path} to /Library/Application Support/Dortania/")
-        utilities.process_status(utilities.elevated(["ditto", path, "/Library/Application Support/Dortania/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+        utilities.process_status(utilities.elevated(["/usr/bin/ditto", path, "/Library/Application Support/Dortania/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
 
         if not Path("/Library/Application Support/Dortania/OpenCore-Patcher.app").exists():
             # Sometimes the binary the user launches may have a suffix (ie. OpenCore-Patcher 3.app)
             # We'll want to rename it to OpenCore-Patcher.app
             path = path.split("/")[-1]
             logging.info(f"- Renaming {path} to OpenCore-Patcher.app")
-            utilities.process_status(utilities.elevated(["mv", f"/Library/Application Support/Dortania/{path}", "/Library/Application Support/Dortania/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+            utilities.process_status(utilities.elevated(["/bin/mv", f"/Library/Application Support/Dortania/{path}", "/Library/Application Support/Dortania/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
 
-        subprocess.run(["xattr", "-cr", "/Library/Application Support/Dortania/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(["/usr/bin/xattr", "-cr", "/Library/Application Support/Dortania/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         # Making app alias
         # Simply an easy way for users to notice the app
         # If there's already an alias or exiting app, skip
         if not Path("/Applications/OpenCore-Patcher.app").exists():
             logging.info("- Making app alias")
-            utilities.process_status(utilities.elevated(["ln", "-s", "/Library/Application Support/Dortania/OpenCore-Patcher.app", "/Applications/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+            utilities.process_status(utilities.elevated(["/bin/ln", "-s", "/Library/Application Support/Dortania/OpenCore-Patcher.app", "/Applications/OpenCore-Patcher.app"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
 
 
     def _create_rsr_monitor_daemon(self) -> bool:
@@ -444,7 +444,7 @@ Please check the Github page for more information about this release."""
         # Load the RSRMonitor plist
         rsr_monitor_plist = plistlib.load(open(self.constants.rsr_monitor_launch_daemon_path, "rb"))
 
-        arguments = ["rm", "-Rfv"]
+        arguments = ["/bin/rm", "-Rfv"]
         arguments += [f"/Library/Extensions/{kext}" for kext in kexts]
 
         # Add the arguments to the RSRMonitor plist

--- a/resources/sys_patch/sys_patch_helpers.py
+++ b/resources/sys_patch/sys_patch_helpers.py
@@ -185,7 +185,7 @@ class SysPatchHelpers:
         if did_find:
             with open(file_path, "wb") as f:
                 plistlib.dump(data, f, sort_keys=False)
-            subprocess.run(["killall", "NotificationCenter"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            subprocess.run(["/usr/bin/killall", "NotificationCenter"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
 
     def install_rsr_repair_binary(self):
@@ -274,6 +274,6 @@ class SysPatchHelpers:
 
             src_dir = f"{LIBRARY_DIR}/{file.name}"
             if not Path(f"{DEST_DIR}/lib").exists():
-                utilities.process_status(utilities.elevated(["cp", "-cR", f"{src_dir}/lib", f"{DEST_DIR}/"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
+                utilities.process_status(utilities.elevated(["/bin/cp", "-cR", f"{src_dir}/lib", f"{DEST_DIR}/"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT))
 
             break

--- a/resources/utilities.py
+++ b/resources/utilities.py
@@ -125,7 +125,7 @@ def check_if_root_is_apfs_snapshot():
 
 def check_seal():
     # 'Snapshot Sealed' property is only listed on booted snapshots
-    sealed = subprocess.run(["diskutil", "apfs", "list"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    sealed = subprocess.run(["/usr/sbin/diskutil", "apfs", "list"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     if "Snapshot Sealed:           Yes" in sealed.stdout.decode():
         return True
     else:
@@ -133,7 +133,7 @@ def check_seal():
 
 def check_filesystem_type():
     # Expected to return 'apfs' or 'hfs'
-    filesystem_type = plistlib.loads(subprocess.run(["diskutil", "info", "-plist", "/"], stdout=subprocess.PIPE).stdout.decode().strip().encode())
+    filesystem_type = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", "/"], stdout=subprocess.PIPE).stdout.decode().strip().encode())
     return filesystem_type["FilesystemType"]
 
 
@@ -187,10 +187,10 @@ def check_kext_loaded(bundle_id: str) -> str:
     # no UUID for kextstat
     pattern = re.compile(re.escape(bundle_id) + r"\s+\((?P<version>.+)\)")
 
-    args = ["kextstat", "-l", "-b", bundle_id]
+    args = ["/usr/sbin/kextstat", "-list-only", "-bundle-id", bundle_id]
 
     if Path("/usr/bin/kmutil").exists():
-        args = ["kmutil", "showloaded", "--list-only", "--variant-suffix", "release", "--optional-identifier", bundle_id]
+        args = ["/usr/bin/kmutil", "showloaded", "--list-only", "--variant-suffix", "release", "--optional-identifier", bundle_id]
 
     kext_loaded = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     if kext_loaded.returncode != 0:
@@ -420,7 +420,7 @@ def find_apfs_physical_volume(device):
     disk_list = None
     physical_disks = []
     try:
-        disk_list = plistlib.loads(subprocess.run(["diskutil", "info", "-plist", device], stdout=subprocess.PIPE).stdout)
+        disk_list = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", device], stdout=subprocess.PIPE).stdout)
     except TypeError:
         pass
 
@@ -465,7 +465,7 @@ def find_disk_off_uuid(uuid):
     # Find disk by UUID
     disk_list = None
     try:
-        disk_list = plistlib.loads(subprocess.run(["diskutil", "info", "-plist", uuid], stdout=subprocess.PIPE).stdout)
+        disk_list = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", uuid], stdout=subprocess.PIPE).stdout)
     except TypeError:
         pass
     if disk_list:
@@ -497,7 +497,7 @@ def grab_mount_point_from_disk(disk):
 
 def monitor_disk_output(disk):
     # Returns MB written on drive
-    output = subprocess.check_output(["iostat", "-Id", disk])
+    output = subprocess.check_output(["/usr/sbin/iostat", "-Id", disk])
     output = output.decode("utf-8")
     #  Grab second last entry (last is \n)
     output = output.split(" ")
@@ -509,7 +509,7 @@ def get_preboot_uuid() -> str:
     """
     Get the UUID of the Preboot volume
     """
-    args = ["ioreg", "-a", "-n", "chosen", "-p", "IODeviceTree", "-r"]
+    args = ["/usr/sbin/ioreg", "-a", "-n", "chosen", "-p", "IODeviceTree", "-r"]
     output = plistlib.loads(subprocess.run(args, stdout=subprocess.PIPE).stdout)
     return output[0]["apfs-preboot-uuid"].strip(b"\0").decode()
 
@@ -533,13 +533,13 @@ def block_os_updaters():
             if bad_process in current_process:
                 if pid != "":
                     logging.info(f"Killing Process: {pid} - {current_process.split('/')[-1]}")
-                    subprocess.run(["kill", "-9", pid])
+                    subprocess.run(["/bin/kill", "-9", pid])
                     break
 
 def check_boot_mode():
     # Check whether we're in Safe Mode or not
     try:
-        sys_plist = plistlib.loads(subprocess.run(["system_profiler", "SPSoftwareDataType"], stdout=subprocess.PIPE).stdout)
+        sys_plist = plistlib.loads(subprocess.run(["/usr/sbin/system_profiler", "SPSoftwareDataType"], stdout=subprocess.PIPE).stdout)
         return sys_plist[0]["_items"][0]["boot_mode"]
     except (KeyError, TypeError, plistlib.InvalidFileException):
         return None
@@ -550,7 +550,7 @@ def elevated(*args, **kwargs) -> subprocess.CompletedProcess:
     if os.getuid() == 0 or check_cli_args() is not None:
         return subprocess.run(*args, **kwargs)
     else:
-        return subprocess.run(["sudo"] + [args[0][0]] + args[0][1:], **kwargs)
+        return subprocess.run(["/usr/bin/sudo"] + [args[0][0]] + args[0][1:], **kwargs)
 
 
 def fetch_staged_update(variant: str = "Update") -> (str, str):

--- a/resources/utilities.py
+++ b/resources/utilities.py
@@ -108,13 +108,14 @@ def check_recovery():
 
 
 def get_disk_path():
-    root_partition_info = plistlib.loads(subprocess.run("diskutil info -plist /".split(), stdout=subprocess.PIPE).stdout.decode().strip().encode())
+    root_partition_info = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", "/"], stdout=subprocess.PIPE).stdout.decode().strip().encode())
     root_mount_path = root_partition_info["DeviceIdentifier"]
     root_mount_path = root_mount_path[:-2] if root_mount_path.count("s") > 1 else root_mount_path
     return root_mount_path
 
+
 def check_if_root_is_apfs_snapshot():
-    root_partition_info = plistlib.loads(subprocess.run("diskutil info -plist /".split(), stdout=subprocess.PIPE).stdout.decode().strip().encode())
+    root_partition_info = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", "/"], stdout=subprocess.PIPE).stdout.decode().strip().encode())
     try:
         is_snapshotted = root_partition_info["APFSSnapshot"]
     except KeyError:
@@ -213,7 +214,7 @@ def check_oclp_boot():
 def check_monterey_wifi():
     IO80211ElCap = "com.apple.iokit.IO80211ElCap"
     CoreCaptureElCap = "com.apple.driver.corecaptureElCap"
-    loaded_kexts: str = subprocess.run("kextcache".split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode()
+    loaded_kexts: str = subprocess.run(["/usr/sbin/kextcache"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode()
     if IO80211ElCap in loaded_kexts and CoreCaptureElCap in loaded_kexts:
         return True
     else:
@@ -307,7 +308,7 @@ def patching_status(os_sip, os):
 
     if os > os_data.os_data.catalina and not check_filevault_skip():
         # Assume non-OCLP Macs do not have our APFS seal patch
-        fv_status: str = subprocess.run("fdesetup status".split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode()
+        fv_status: str = subprocess.run(["/usr/bin/fdesetup", "status"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout.decode()
         if "FileVault is Off" in fv_status:
             fv_enabled = False
     else:
@@ -340,8 +341,7 @@ def cls():
 
 def check_command_line_tools():
     # Determine whether Command Line Tools exist
-    # xcode-select -p
-    xcode_select = subprocess.run("xcode-select -p".split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    xcode_select = subprocess.run(["/usr/bin/xcode-select", "--print-path"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     if xcode_select.returncode == 0:
         return True
     else:
@@ -492,7 +492,7 @@ def get_free_space(disk=None):
     return free
 
 def grab_mount_point_from_disk(disk):
-    data = plistlib.loads(subprocess.run(f"diskutil info -plist {disk}".split(), stdout=subprocess.PIPE).stdout.decode().strip().encode())
+    data = plistlib.loads(subprocess.run(["/usr/sbin/diskutil", "info", "-plist", disk], stdout=subprocess.PIPE).stdout.decode().strip().encode())
     return data["MountPoint"]
 
 def monitor_disk_output(disk):

--- a/resources/validation.py
+++ b/resources/validation.py
@@ -143,7 +143,7 @@ class PatcherValidation:
         logging.info("Validating Root Patch File integrity")
         output = subprocess.run(
             [
-                "hdiutil", "attach", "-noverify", f"{self.constants.payload_local_binaries_root_path_dmg}",
+                "/usr/bin/hdiutil", "attach", "-noverify", f"{self.constants.payload_local_binaries_root_path_dmg}",
                 "-mountpoint", Path(self.constants.payload_path / Path("Universal-Binaries")),
                 "-nobrowse",
                 "-shadow", Path(self.constants.payload_path / Path("Universal-Binaries_overlay")),
@@ -172,7 +172,7 @@ class PatcherValidation:
         # unmount the dmg
         output = subprocess.run(
             [
-                "hdiutil", "detach", Path(self.constants.payload_path / Path("Universal-Binaries")),
+                "/usr/bin/hdiutil", "detach", Path(self.constants.payload_path / Path("Universal-Binaries")),
                 "-force"
             ],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT
@@ -187,7 +187,7 @@ class PatcherValidation:
 
         subprocess.run(
             [
-                "rm", "-f", Path(self.constants.payload_path / Path("Universal-Binaries_overlay"))
+                "/bin/rm", "-f", Path(self.constants.payload_path / Path("Universal-Binaries_overlay"))
             ],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )
@@ -222,4 +222,4 @@ class PatcherValidation:
         self._build_prebuilt()
         self._build_dumps()
 
-        subprocess.run(["rm", "-rf", self.constants.build_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        subprocess.run(["/bin/rm", "-rf", self.constants.build_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/resources/wx_gui/gui_macos_installer_flash.py
+++ b/resources/wx_gui/gui_macos_installer_flash.py
@@ -428,8 +428,8 @@ class macOSInstallerFlashFrame(wx.Frame):
         if not str(path).endswith(".zip"):
             return
         if Path(self.constants.installer_pkg_path).exists():
-            subprocess.run(["rm", self.constants.installer_pkg_path])
-        subprocess.run(["ditto", "-V", "-x", "-k", "--sequesterRsrc", "--rsrc", self.constants.installer_pkg_zip_path, self.constants.payload_path])
+            subprocess.run(["/bin/rm", self.constants.installer_pkg_path])
+        subprocess.run(["/usr/bin/ditto", "-V", "-x", "-k", "--sequesterRsrc", "--rsrc", self.constants.installer_pkg_zip_path, self.constants.payload_path])
 
 
     def _install_installer_pkg(self, disk):
@@ -448,8 +448,8 @@ class macOSInstallerFlashFrame(wx.Frame):
             logging.info("Installer unsupported, requires Big Sur or newer")
             return
 
-        subprocess.run(["mkdir", "-p", f"{path}/Library/Packages/"])
-        subprocess.run(["cp", "-r", self.constants.installer_pkg_path, f"{path}/Library/Packages/"])
+        subprocess.run(["/bin/mkdir", "-p", f"{path}/Library/Packages/"])
+        subprocess.run(["/bin/cp", "-r", self.constants.installer_pkg_path, f"{path}/Library/Packages/"])
 
         self._kdk_chainload(os_version["ProductBuildVersion"], os_version["ProductVersion"], Path(path + "/Library/Packages/"))
 
@@ -512,17 +512,17 @@ class macOSInstallerFlashFrame(wx.Frame):
         # Now that we have a KDK, extract it to get the pkg
         with tempfile.TemporaryDirectory() as mount_point:
             logging.info("Mounting KDK")
-            result = subprocess.run(["hdiutil", "attach", kdk_dmg_path, "-mountpoint", mount_point, "-nobrowse"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            result = subprocess.run(["/usr/bin/hdiutil", "attach", kdk_dmg_path, "-mountpoint", mount_point, "-nobrowse"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             if result.returncode != 0:
                 logging.info("Failed to mount KDK")
                 logging.info(result.stdout.decode("utf-8"))
                 return
 
             logging.info("Copying KDK")
-            subprocess.run(["cp", "-r", f"{mount_point}/KernelDebugKit.pkg", kdk_pkg_path])
+            subprocess.run(["/bin/cp", "-r", f"{mount_point}/KernelDebugKit.pkg", kdk_pkg_path])
 
             logging.info("Unmounting KDK")
-            result = subprocess.run(["hdiutil", "detach", mount_point], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            result = subprocess.run(["/usr/bin/hdiutil", "detach", mount_point], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             if result.returncode != 0:
                 logging.info("Failed to unmount KDK")
                 logging.info(result.stdout.decode("utf-8"))
@@ -545,7 +545,7 @@ class macOSInstallerFlashFrame(wx.Frame):
                 logging.error(f"Failed to find {dmg_path}")
                 error_message = f"Failed to find {dmg_path}"
                 return error_message
-            result = subprocess.run(["hdiutil", "verify", dmg_path],stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            result = subprocess.run(["/usr/bin/hdiutil", "verify", dmg_path],stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if result.returncode != 0:
                 if result.stdout:
                     logging.error(result.stdout.decode("utf-8"))

--- a/resources/wx_gui/gui_main_menu.py
+++ b/resources/wx_gui/gui_main_menu.py
@@ -261,13 +261,13 @@ class MainFrame(wx.Frame):
         if Path("/Applications/OpenCore-Patcher.app").exists() and Path("/Applications/OpenCore-Patcher.app").is_symlink() is False:
             logging.info("Found user-installed app in /Applications, replacing with symlink")
             # Delete app
-            result = subprocess.run(["rm", "-rf", "/Applications/OpenCore-Patcher.app"], capture_output=True)
+            result = subprocess.run(["/bin/rm", "-rf", "/Applications/OpenCore-Patcher.app"], capture_output=True)
             if result.returncode != 0:
                 logging.info("Failed to delete app from /Applications")
                 return
 
             # Create symlink
-            result = subprocess.run(["ln", "-s", "/Library/Application Support/Dortania/OpenCore-Patcher.app", "/Applications/OpenCore-Patcher.app"], capture_output=True)
+            result = subprocess.run(["/bin/ln", "-s", "/Library/Application Support/Dortania/OpenCore-Patcher.app", "/Applications/OpenCore-Patcher.app"], capture_output=True)
             if result.returncode != 0:
                 logging.info("Failed to create symlink to /Applications")
                 return

--- a/resources/wx_gui/gui_settings.py
+++ b/resources/wx_gui/gui_settings.py
@@ -1152,7 +1152,7 @@ Hardware Information:
         if dlg.ShowModal() != wx.ID_YES:
             return
 
-        macserial_output = subprocess.run([self.constants.macserial_path] + f"-g -m {self.constants.custom_model or self.constants.computer.real_model} -n 1".split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        macserial_output = subprocess.run([self.constants.macserial_path, "--generate", "--model", self.constants.custom_model or self.constants.computer.real_model, "--num", "1"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         macserial_output = macserial_output.stdout.decode().strip().split(" | ")
         if len(macserial_output) == 2:
             self.custom_serial_number_textbox.SetValue(macserial_output[0])

--- a/resources/wx_gui/gui_settings.py
+++ b/resources/wx_gui/gui_settings.py
@@ -1110,7 +1110,7 @@ Hardware Information:
             value_type = "-bool"
 
         logging.info(f"Updating System Defaults: {variable} = {value} ({value_type})")
-        subprocess.run(["defaults", "write", "-g", variable, value_type, str(value)])
+        subprocess.run(["/usr/bin/defaults", "write", "-globalDomain", variable, value_type, str(value)])
 
 
     def _find_parent_for_key(self, key: str) -> str:
@@ -1256,7 +1256,7 @@ Hardware Information:
 
 
     def _get_system_settings(self, variable) -> bool:
-        result = subprocess.run(["defaults", "read", "-g", variable], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        result = subprocess.run(["/usr/bin/defaults", "read", "-globalDomain", variable], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         if result.returncode == 0:
             try:
                 return bool(int(result.stdout.decode().strip()))

--- a/resources/wx_gui/gui_support.py
+++ b/resources/wx_gui/gui_support.py
@@ -64,7 +64,7 @@ class GenerateMenubar:
 
         self.frame.Bind(wx.EVT_MENU, lambda event: gui_about.AboutFrame(self.constants), aboutItem)
         self.frame.Bind(wx.EVT_MENU, lambda event: RelaunchApplicationAsRoot(self.frame, self.constants).relaunch(None), relaunchItem)
-        self.frame.Bind(wx.EVT_MENU, lambda event: subprocess.run(["open", "-R", self.constants.log_filepath]), revealLogItem)
+        self.frame.Bind(wx.EVT_MENU, lambda event: subprocess.run(["/usr/bin/open", "--reveal", self.constants.log_filepath]), revealLogItem)
 
         if os.geteuid() == 0:
             relaunchItem.Enable(False)
@@ -329,7 +329,7 @@ class RelaunchApplicationAsRoot:
 
         # Relaunch as root
         args = [
-            "osascript",
+            "/usr/bin/osascript",
             "-e",
             f'''do shell script "{program_arguments}"'''
             ' with prompt "OpenCore Legacy Patcher needs administrator privileges to relaunch as admin."'

--- a/resources/wx_gui/gui_sys_patch_start.py
+++ b/resources/wx_gui/gui_sys_patch_start.py
@@ -318,7 +318,7 @@ class SysPatchStartFrame(wx.Frame):
         if answer == wx.ID_YES:
             output =subprocess.run(
                 [
-                    "osascript", "-e",
+                    "/usr/bin/osascript", "-e",
                     'tell app "System Preferences" to activate',
                     "-e", 'tell app "System Preferences" to reveal anchor "General" of pane id "com.apple.preference.security"',
                 ],
@@ -327,7 +327,7 @@ class SysPatchStartFrame(wx.Frame):
             )
             if output.returncode != 0:
                 # Some form of fallback if unaccelerated state errors out
-                subprocess.run(["open", "-a", "System Preferences"])
+                subprocess.run(["/usr/bin/open", "-a", "System Preferences"])
             time.sleep(5)
             sys.exit(0)
 

--- a/resources/wx_gui/gui_update.py
+++ b/resources/wx_gui/gui_update.py
@@ -184,13 +184,13 @@ class UpdateFrame(wx.Frame):
         """
         logging.info("Extracting update")
         if Path(self.application_path).exists():
-            subprocess.run(["rm", "-rf", str(self.application_path)])
+            subprocess.run(["/bin/rm", "-rf", str(self.application_path)])
 
         # Some hell spawn at Github decided to double zip our Github Actions artifacts
         # So we need to unzip it twice
         for i in range(2):
             result = subprocess.run(
-                ["ditto", "-xk", str(self.constants.payload_path / "OpenCore-Patcher-GUI.app.zip"), str(self.constants.payload_path)], capture_output=True
+                ["/usr/bin/ditto", "-xk", str(self.constants.payload_path / "OpenCore-Patcher-GUI.app.zip"), str(self.constants.payload_path)], capture_output=True
             )
             if result.returncode != 0:
                 logging.error(f"Failed to extract update. Error: {result.stderr.decode('utf-8')}")


### PR DESCRIPTION
* Use full binary paths to avoid conflicts with local environment
* Use full argument names when application
* Avoid usage of split()