### PR TITLE
Add SkipLogo patch for Macs natively supporting Monterey or newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # OpenCore Legacy Patcher changelog
 
 ## 1.5.0
+- Patch SkipLogo on Macs that natively support Monterey or newer
+  - Resolves missing Apple logo on boot screen
 - Increment Binaries:
   - OpenCorePkg 0.9.9 - release
 

--- a/payloads/Config/config.plist
+++ b/payloads/Config/config.plist
@@ -265,6 +265,30 @@
 				<key>Skip</key>
 				<integer>0</integer>
 			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>x86_64</string>
+				<key>Comment</key>
+				<string>Patch SkipLogo</string>
+				<key>Count</key>
+				<integer>0</integer>
+				<key>Enabled</key>
+				<false/>
+				<key>Find</key>
+				<data>UwBrAGkAcABMAG8AZwBv</data>
+				<key>Identifier</key>
+				<string>Apple</string>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data></data>
+				<key>Replace</key>
+				<data>QQBrAGkAcABMAG8AZwBv</data>
+				<key>ReplaceMask</key>
+				<data></data>
+				<key>Skip</key>
+				<integer>0</integer>
+			</dict>
 		</array>
 		<key>Quirks</key>
 		<dict>

--- a/resources/build/firmware.py
+++ b/resources/build/firmware.py
@@ -45,13 +45,13 @@ class BuildFirmware:
         Apple logo Handling
         """
 
-        # Macs that natively support Monterey (excluding MacPro6,1) won't have boot.efi draw the Apple logo.
+        # Macs that natively support Monterey (excluding MacPro6,1 and Macmini7,1) won't have boot.efi draw the Apple logo.
         # This causes a cosmetic issue when booting through OpenCore, as the Apple logo will be missing.
 
         if not self.model in smbios_data.smbios_dictionary:
             return
 
-        if smbios_data.smbios_dictionary[self.model]["Max OS Supported"] >= os_data.os_data.monterey and self.model != "MacPro6,1":
+        if smbios_data.smbios_dictionary[self.model]["Max OS Supported"] >= os_data.os_data.monterey and self.model not in ["MacPro6,1", "Macmini7,1"]:
             logging.info("- Enabling Boot Logo patch")
             support.BuildSupport(self.model, self.constants, self.config).get_item_by_kv(self.config["Booter"]["Patch"], "Comment", "Patch SkipLogo")["Enabled"] = True
 

--- a/resources/build/firmware.py
+++ b/resources/build/firmware.py
@@ -50,8 +50,6 @@ class BuildFirmware:
 
         if not self.model in smbios_data.smbios_dictionary:
             return
-        if not "Max OS Supported" in smbios_data.smbios_dictionary[self.model]:
-            return
 
         if smbios_data.smbios_dictionary[self.model]["Max OS Supported"] >= os_data.os_data.monterey and self.model != "MacPro6,1":
             logging.info("- Enabling Boot Logo patch")


### PR DESCRIPTION
This PR fixes a cosmetic issue where the Apple logo won't get rendered.

This is because boot.efi checks for SkipLogo not being present before drawing the Apple logo by itself and assuming that the logo is already drawn if SkipLogo is present. However, if the screen gets cleared after the logo is drawn by the firmware (i.e. bootpicker is used), no Apple logo will appear. This appears to be an oversight by Apple.