### PR TITLE
Fix root patch troubleshooting docs

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -71,7 +71,7 @@ Now we're going to clean the /Library/Extensions folder from offending kexts whi
 Run the following and **make sure to type it carefully**
 
 ```sh
-cd "/Volumes/Macintosh HD/Library/Extensions" && ls | grep -v "HighPoint*\|SoftRAID*" | xargs rm -rf
+cd "/Volumes/Macintosh HD - Data/Library/Extensions" && ls | grep -v "HighPoint*\|SoftRAID*" | xargs rm -rf
 ```
 
 Then restart and now your system should be restored to the unpatched snapshot and should be able to boot again.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -70,6 +70,10 @@ Now we're going to clean the /Library/Extensions folder from offending kexts whi
 
 Run the following and **make sure to type it carefully**
 
+::: warning
+If you have **FileVault 2 enabled**, you will need to mount the Data volume first. This can be done in Disk Utility by locating your macOS volume name, selecting its Data volume, and selecting the Mount option in the toolbar.
+:::
+
 ```sh
 cd "/Volumes/Macintosh HD - Data/Library/Extensions" && ls | grep -v "HighPoint*\|SoftRAID*" | xargs rm -rf
 ```


### PR DESCRIPTION
Noticed a few issues with this page after a user was unable to enter the commands correctly.

First, the original command was referencing `/Volumes/Macintosh HD/Library/Extensions`. Because recoveryOS does not firmlink a macOS Data volume to its paired System volume, that directory does not exist and this troubleshooting step is incorrect. 
- I have updated the volume path with `- Data`, to point to the Data volume.

Second, the original documentation did not have any information on users with FileVault 2 enabled. While recoveryOS asks for a user password in order to access its tools, it does not mount the Data volume.
- I have added a note on how to easily identify and mount the Data volume here.