### PR TITLE
Add missing MacBook Pro models to the supported list

### DIFF
--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -58,7 +58,7 @@ The patcher is designed to target **macOS Big Sur 11.x to macOS Sonoma 14.x**.
 | Model Name | Identifier | Tagged Issues |
 | :--- | :--- | :--- |
 | MacBook Pro (15-inch, Early 2008)<br>MacBook Pro (17-inch, Early 2008) | `MacBookPro4,1` | - [non-Metal GPU (macOS 11+)](https://github.com/dortania/OpenCore-Legacy-Patcher/issues/108)<br>- [USB 1.1 (macOS 13+)](https://github.com/dortania/OpenCore-Legacy-Patcher/issues/1021)|
-| MacBook Pro (15-inch, Late 2008) | `MacBookPro5,1` | ^^ |
+| MacBook Pro (15-inch, Late 2008)<br>MacBook Pro (15-inch, Early 2009) | `MacBookPro5,1` | ^^ |
 | MacBook Pro (17-inch, Early 2009)<br>MacBook Pro (17-inch, Mid 2009) | `MacBookPro5,2` | ^^ |
 | MacBook Pro (15-inch, Mid 2009) | `MacBookPro5,3`<br>`MacBookPro5,4` | ^^ |
 | MacBook Pro (13-inch, Mid 2009) | `MacBookPro5,5` | ^^ |

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -60,7 +60,7 @@ The patcher is designed to target **macOS Big Sur 11.x to macOS Sonoma 14.x**.
 | MacBook Pro (15-inch, Early 2008)<br>MacBook Pro (17-inch, Early 2008) | `MacBookPro4,1` | - [non-Metal GPU (macOS 11+)](https://github.com/dortania/OpenCore-Legacy-Patcher/issues/108)<br>- [USB 1.1 (macOS 13+)](https://github.com/dortania/OpenCore-Legacy-Patcher/issues/1021)|
 | MacBook Pro (15-inch, Late 2008) | `MacBookPro5,1` | ^^ |
 | MacBook Pro (17-inch, Early 2009)<br>MacBook Pro (17-inch, Mid 2009) | `MacBookPro5,2` | ^^ |
-| MacBook Pro (15-inch, Mid 2009) | `MacBookPro5,3` | ^^ |
+| MacBook Pro (15-inch, Mid 2009) | `MacBookPro5,3`<br>`MacBookPro5,4` | ^^ |
 | MacBook Pro (13-inch, Mid 2009) | `MacBookPro5,5` | ^^ |
 | MacBook Pro (17-inch, Mid 2010) | `MacBookPro6,1` | - [non-Metal GPU (macOS 11+)](https://github.com/dortania/OpenCore-Legacy-Patcher/issues/108) |
 | MacBook Pro (15-inch, Mid 2010) | `MacBookPro6,2` | ^^ |


### PR DESCRIPTION
This PR adds the following:
- Adds missing `MacBookPro5,4` ID for the `MacBook Pro (15-inch, Mid 2009)`.
- Adds missing `MacBook Pro (15-inch, Early 2009)` for the `MacBookPro5,1` ID.