### PR TITLE
Increase model range of S1X/S3X kext inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Implement new Copy on Write detection mechanism for all file copying operations
   - Implemented using `getattrlist` and `VOL_CAP_INT_CLONE` flag
   - Helps improve performance on APFS volumes
+- Increase model range for S1X/S3X patching to include Haswell Macs and `MacPro6,1`
+  - Helps avoid an issue where older machines with newer, unsupported SSDs would fail to boot
+  - Only affects building EFI from another machine
 - Increment Binaries:
   - PatcherSupportPkg 1.6.3 - release
 

--- a/opencore_legacy_patcher/efi_builder/storage.py
+++ b/opencore_legacy_patcher/efi_builder/storage.py
@@ -152,7 +152,7 @@ class BuildStorage:
         # Apple's usage of the S1X and S3X is quite sporadic and inconsistent, so we'll try a catch all for units with NVMe drives
         if self.constants.custom_model and self.model in smbios_data.smbios_dictionary:
             if "CPU Generation" in smbios_data.smbios_dictionary[self.model]:
-                if cpu_data.CPUGen.broadwell <= smbios_data.smbios_dictionary[self.model]["CPU Generation"] <= cpu_data.CPUGen.kaby_lake:
+                if cpu_data.CPUGen.haswell <= smbios_data.smbios_dictionary[self.model]["CPU Generation"] <= cpu_data.CPUGen.kaby_lake or self.model in [ "MacPro6,1" ]:
                     support.BuildSupport(self.model, self.constants, self.config).enable_kext("IOS3XeFamily.kext", self.constants.s3x_nvme_version, self.constants.s3x_nvme_path)
 
         # Apple RAID Card check

--- a/opencore_legacy_patcher/efi_builder/storage.py
+++ b/opencore_legacy_patcher/efi_builder/storage.py
@@ -150,9 +150,10 @@ class BuildStorage:
 
         # Restore S1X/S3X NVMe support removed in 14.0 Beta 2
         # Apple's usage of the S1X and S3X is quite sporadic and inconsistent, so we'll try a catch all for units with NVMe drives
+        # Additionally expanded to cover all Mac models with the 12+16 pin SSD layout, for older machines with newer drives
         if self.constants.custom_model and self.model in smbios_data.smbios_dictionary:
             if "CPU Generation" in smbios_data.smbios_dictionary[self.model]:
-                if cpu_data.CPUGen.haswell <= smbios_data.smbios_dictionary[self.model]["CPU Generation"] <= cpu_data.CPUGen.kaby_lake or self.model in [ "MacPro6,1" ]:
+                if (cpu_data.CPUGen.haswell <= smbios_data.smbios_dictionary[self.model]["CPU Generation"] <= cpu_data.CPUGen.kaby_lake) or self.model in [ "MacPro6,1" ]:
                     support.BuildSupport(self.model, self.constants, self.config).enable_kext("IOS3XeFamily.kext", self.constants.s3x_nvme_version, self.constants.s3x_nvme_path)
 
         # Apple RAID Card check


### PR DESCRIPTION
While stock systems with S1X/S3X drives only include Broadwell to Kaby Lake Macs, Haswell Macs and MacPro6,1 are able to use these drives as well, causing issues when building OpenCore for those models from a different machine.

Tested locally with `Macmini7,1` and `MacPro6,1` SMBIOSes.