### PR TITLE
Implement new modern wireless patchset

### DIFF
--- a/opencore_legacy_patcher/sys_patch/patchsets/detect.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/detect.py
@@ -200,7 +200,7 @@ class HardwarePatchsetDetection:
             logging.error("Installed patches are from different commit, unpatching is required")
             return True
 
-        wireless_keys = {"Legacy Wireless", "Modern Wireless"}
+        wireless_keys = {"Legacy Wireless", "Modern Wireless Common"}
 
         # Keep in sync with generate_patchset_plist
         metadata_keys = {

--- a/opencore_legacy_patcher/sys_patch/patchsets/hardware/networking/modern_wireless.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/hardware/networking/modern_wireless.py
@@ -56,7 +56,7 @@ class ModernWireless(BaseHardware):
         """
         Extended modern wireless patches
         """
-        if self.native_os() is True:
+        if self._xnu_major > os_data.sonoma:
             return {}
 
         return {
@@ -82,9 +82,6 @@ class ModernWireless(BaseHardware):
         """
         Common modern wireless patches
         """
-        if self.native_os() is True:
-            return {}
-
         return {
             "Modern Wireless Common": {
                 PatchType.OVERWRITE_SYSTEM_VOLUME: {
@@ -105,14 +102,12 @@ class ModernWireless(BaseHardware):
         """
         Dictionary of patches
         """
+        if self.native_os() is True:
+            return {}
 
-        _base = {
+        return {
             **self._patches_modern_wireless_common(),
+            **self._patches_modern_wireless_common_extended(),
         }
-
-        if self._xnu_major == os_data.sonoma:
-            _base.update({
-                **self._patches_modern_wireless_common_extended(),
-            })
 
         return _base


### PR DESCRIPTION
Depends on [PatcherSupportPkg #17](https://github.com/dortania/PatcherSupportPkg/pull/17)

macOS Sequoia and Tahoe use a more slimmed down patchset compared to what was previously used.

macOS Sonoma is not included in these updates.

Credit to EduCovas for the patches.